### PR TITLE
Added logout command

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
         "title": "View Diagram"
       },
       {
+        "command": "mermaidChart.logout",
+        "title": "MermaidChart Logout"
+      },
+      {
         "command": "mermaidChart.editMermaidChart",
         "title": "Edit Diagram"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,12 @@ export async function activate(context: vscode.ExtensionContext) {
   const mcAPI = new MermaidChartVSCode();
   await mcAPI.initialize(context);
 
+  context.subscriptions.push(
+    vscode.commands.registerCommand('mermaidChart.logout', async () => {
+      mcAPI.logout(context);
+    })
+  );
+
   const mermaidChartProvider: MermaidChartProvider = new MermaidChartProvider(
     mcAPI
   );

--- a/src/mermaidChartAuthenticationProvider.ts
+++ b/src/mermaidChartAuthenticationProvider.ts
@@ -37,6 +37,21 @@ export class MermaidChartAuthenticationProvider
   >();
   private _uriHandler = new UriEventHandler();
 
+  private static instance: MermaidChartAuthenticationProvider | null = null;
+
+  static getInstance(
+    mcAPI: MermaidChartVSCode,
+    context: ExtensionContext
+  ): MermaidChartAuthenticationProvider {
+    if (!MermaidChartAuthenticationProvider.instance) {
+      MermaidChartAuthenticationProvider.instance = new MermaidChartAuthenticationProvider(
+        mcAPI,
+        context
+      );
+    }
+    return MermaidChartAuthenticationProvider.instance;
+  }
+
   constructor(
     private readonly mcAPI: MermaidChartVSCode,
     private readonly context: ExtensionContext

--- a/src/mermaidChartVSCode.ts
+++ b/src/mermaidChartVSCode.ts
@@ -17,6 +17,23 @@ export class MermaidChartVSCode extends MermaidChart {
     await this.setupAPI();
   }
 
+  public async logout(context: vscode.ExtensionContext): Promise<void> {
+    const session = await vscode.authentication.getSession(
+      MermaidChartAuthenticationProvider.id,
+      [],
+      { silent: true }
+    );
+  
+    if (session) {
+      const authProvider = MermaidChartAuthenticationProvider.getInstance(this, context);
+      await authProvider.removeSession(session.id);
+      vscode.window.showInformationMessage(`You have successfully signed out from ${session.account.id}.`);
+    } else {
+      vscode.window.showInformationMessage('No active session found. You are already signed out.');
+    }
+  }
+  
+
   private async registerListeners(context: vscode.ExtensionContext) {
     /**
      * Register the authentication provider with VS Code.
@@ -26,7 +43,7 @@ export class MermaidChartVSCode extends MermaidChart {
       vscode.authentication.registerAuthenticationProvider(
         MermaidChartAuthenticationProvider.id,
         MermaidChartAuthenticationProvider.providerName,
-        new MermaidChartAuthenticationProvider(this, context)
+        MermaidChartAuthenticationProvider.getInstance(this, context)
       )
     );
 


### PR DESCRIPTION
MermaidChart Logout is added to command pallet for users to get logged out from mermaid account

1.  To test locally:

- Take a pull with this branch
- Open in Vsocde code and run the plugin
- This will open new window and will prompt for authentication
- Authenticate with correct user
- use this document for authenticating user (https://mermaidchart.atlassian.net/wiki/spaces/Plugins/pages/457441288/Cursor+Vscode+plugin+testing)
- Open Command Palette
- Select Command: Search for and select the MermaidChart Logout command.
- Execute Logout: Confirm the logout action.
- Verify Logout: Ensure you are logged out and A logout confirmation popup should be displayed.



2. To test After release:

- Install Mermaid Chart Plugin
- Log In: Start by logging into the plugin
- Open Command Palette
- Select Command: Search for and select the MermaidChart Logout command.
- Execute Logout: Confirm the logout action.
- Verify Logout: Ensure you are logged out and A logout confirmation popup should be displayed.
