### PR TITLE
fixed display of ErrorMessage for source code

### DIFF
--- a/webview/src/ErrorMessage.svelte
+++ b/webview/src/ErrorMessage.svelte
@@ -10,7 +10,7 @@
         color: #d8000c;
         padding: 10px;
         font-size: 14px;
-        text-align: center;
+        text-align: left;
         border: 1px solid #d8000c;
         display: none;
         user-select:text;
@@ -22,6 +22,6 @@
   </style>
   <div id="error-message" class:errorVisible={!!errorMessage}>
     {#if errorMessage}
-      <p>{errorMessage}</p>
+      <pre>{errorMessage}</pre>
     {/if}
   </div>


### PR DESCRIPTION
how it looks: 
<p style="text-align:center"> Syntax error in text: can not read a block mapping entry; a multiline key may not be an implicit key (3:2) 1 | a: 2 | b 3 | c: ------^</p>

how it should look:
<pre>
Syntax error in text: can not read a block mapping entry; a multiline key may not be an implicit key (3:2)

 1 | a:
 2 | b
 3 | c:
------^
</pre>
