### PR TITLE
PLUG-51 Only show preview option and connection handling for connected diagrams

### DIFF
--- a/package.json
+++ b/package.json
@@ -739,7 +739,7 @@
         },
         {
           "command": "mermaidChart.connectDiagramToMermaidChart",
-          "when": "resourceExtname =~ /^\\.(mmd|mermaid)$/ || resourceLangId =~ /^mermaid/",
+          "when": "(resourceExtname =~ /^\\.(mmd|mermaid)$/ || resourceLangId =~ /^mermaid/) && !mermaid.hasId",
           "group": "navigation"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,6 +138,7 @@ export async function activate(context: vscode.ExtensionContext) {
       handleTextDocumentChange(event, diagramMappings, false);
       updateMermaidChartTokenHighlighting();
       triggerSuggestIfEmpty(event.document);
+      updateMermaidIdContext(event.document);
     },
     null,
     context.subscriptions
@@ -147,6 +148,7 @@ export async function activate(context: vscode.ExtensionContext) {
     (event) => {
       handleTextDocumentChange(event, diagramMappings, true);
       updateMermaidChartTokenHighlighting();
+      updateMermaidIdContext(event?.document);
     },
     null,
     context.subscriptions
@@ -217,7 +219,29 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   }
 
+  function updateMermaidIdContext(document?: vscode.TextDocument) {
+    if (!document) {
+      vscode.commands.executeCommand("setContext", "mermaid.hasId", false);
+      return;
+    }
+
+    // Check if document is a mermaid file
+    const isMermaidFile = document.languageId.startsWith("mermaid") || 
+                         document.fileName.match(/\.(mmd|mermaid)$/);
+    
+    if (!isMermaidFile) {
+      vscode.commands.executeCommand("setContext", "mermaid.hasId", false);
+      return;
+    }
+
+    // Check if the mermaid document has an ID
+    const content = document.getText();
+    const hasId = extractIdFromCode(content) !== undefined;
+    vscode.commands.executeCommand("setContext", "mermaid.hasId", hasId);
+  }
+
   updateMermaidChartTokenHighlighting();
+  updateMermaidIdContext(vscode.window.activeTextEditor?.document);
 
 
   const viewCommandDisposable = vscode.commands.registerCommand(


### PR DESCRIPTION
This PR changes hide the connect diagram button from the right-click drop-down list on mermaid document and only show it when diagram is not connected to the mermaid account 