### PR TITLE
MC-4527: Markdown Preview Rendering Conflicts with VS Code 1.121 Native Mermaid Renderer (Empty Diagrams)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 2.6.9 - 2026-06-9 
+- Fixed an bug where Mermaid diagrams were not rendering correctly in Markdown files
+
 ### 2.6.7 - 2026-05-29
 - Added **Generate Mermaid Diagram from Code** — This command appears at the bottom of supported code files, or you can directly use `@mermaid-chart /generate_diagram_from_code` to select files, choose a diagram type, and generate Mermaid diagrams using AI.
 - Added **Review Mermaid Sync** — Provides highlight, diff preview, accept, reject, and commit actions for .mmd/.mermaid files updated by the [Mermaid Diagram Sync GitHub App](https://github.com/marketplace/mermaid-diagram-sync); Also includes automatic detection after `git pull` and support for MermaidChart: Connect GitHub for Mermaid Diagram Sync for PR-aware reviews.

--- a/README.md
+++ b/README.md
@@ -492,6 +492,9 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 2.6.9 - 2026-06-9 
+- Fixed an bug where Mermaid diagrams were not rendering correctly in Markdown files
+
 ### 2.6.7 - 2026-05-29
 - Added **Generate Mermaid Diagram from Code** — This command appears at the bottom of supported code files, or you can directly use `@mermaid-chart /generate_diagram_from_code` to select files, choose a diagram type, and generate Mermaid diagrams using AI.
 - Added **Review Mermaid Sync** — Provides highlight, diff preview, accept, reject, and commit actions for .mmd/.mermaid files updated by the [Mermaid Diagram Sync GitHub App](https://github.com/marketplace/mermaid-diagram-sync); Also includes automatic detection after `git pull` and support for MermaidChart: Connect GitHub for Mermaid Diagram Sync for PR-aware reviews.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "MermaidChart",
   "displayName": "Mermaid",
   "description": "The official Mermaid Editor plugin by the Mermaid open source team, now with AI-powered diagramming! Create, edit and preview diagrams seamlessly within VS Code",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "icon": "images/mermaid-chart.png",
   "repository": "github:Mermaid-Chart/vscode-mermaid-chart",
   "engines": {

--- a/src/previewmarkdown/markdown-preview/index.ts
+++ b/src/previewmarkdown/markdown-preview/index.ts
@@ -7,7 +7,7 @@
 import mermaid, { MermaidConfig } from "@mermaid-chart/mermaid";
 import { registerMermaidAddons, renderMermaidBlocksInElement } from '../shared-mermaid';
 
-function init() { 
+async function init() { 
     const configSpan = document.getElementById('markdown-mermaid');
     const darkModeTheme = configSpan?.dataset.darkModeTheme;
     const lightModeTheme = configSpan?.dataset.lightModeTheme;
@@ -22,9 +22,9 @@ function init() {
     };
 
     mermaid.initialize(config);
-    registerMermaidAddons();
-    
-    renderMermaidBlocksInElement(document.body, (mermaidContainer, content) => {
+    await registerMermaidAddons();
+
+    await renderMermaidBlocksInElement(document.body, (mermaidContainer, content) => {
         mermaidContainer.innerHTML = content;
     });
 }

--- a/src/previewmarkdown/shared-md-mermaid/index.ts
+++ b/src/previewmarkdown/shared-md-mermaid/index.ts
@@ -1,6 +1,9 @@
 import type MarkdownIt from 'markdown-it';
 
 const mermaidLanguageId = 'mermaid';
+/** HTML class for our preview renderer — VS Code built-in only targets `.mermaid`. */
+export const mermaidChartContainerClass = 'mermaid-chart';
+export const mermaidChartContainerSelector = `.${mermaidChartContainerClass}`;
 const containerTokenName = 'mermaidContainer';
 
 const min_markers = 3;
@@ -132,7 +135,7 @@ export function extendMarkdownItWithMermaid(md: MarkdownIt, config: { languageId
         md.renderer.rules[containerTokenName] = (tokens: MarkdownIt.Token[], idx: number) => {
             const token = tokens[idx];
             const src = token.content;
-            return `<div class="${mermaidLanguageId}">${preProcess(src)}</div>`;
+            return `<div class="${mermaidChartContainerClass}">${preProcess(src)}</div>`;
         };
     });
 
@@ -140,7 +143,7 @@ export function extendMarkdownItWithMermaid(md: MarkdownIt, config: { languageId
     md.options.highlight = (code: string, lang: string, attrs: string) => {
         const reg = new RegExp('\\b(' + config.languageIds().map(escapeRegExp).join('|') + ')\\b', 'i');
         if (lang && reg.test(lang)) {
-            return `<pre style="all:unset;"><div class="${mermaidLanguageId}">${preProcess(code)}</div></pre>`;
+            return `<pre style="all:unset;"><div class="${mermaidChartContainerClass}">${preProcess(code)}</div></pre>`;
         }
         return highlight?.(code, lang, attrs) ?? code;
     };
@@ -158,4 +161,18 @@ function preProcess(source: string): string {
 
 function escapeRegExp(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Renames built-in `.mermaid` divs to `.mermaid-chart` so only our preview script renders them. */
+export function prepareMermaidChartHtml(html: string): string {
+    return html.replace(
+        /<div\b([^>]*\bclass=")([^"]*)"([^>]*)>/gi,
+        (full, before: string, classes: string, after: string) => {
+            if (!/\bmermaid\b/.test(classes) || classes.includes(mermaidChartContainerClass)) {
+                return full;
+            }
+            const newClasses = classes.replace(/\bmermaid\b/, mermaidChartContainerClass);
+            return `<div${before}${newClasses}"${after}>`;
+        }
+    );
 }

--- a/src/previewmarkdown/shared-mermaid/index.ts
+++ b/src/previewmarkdown/shared-mermaid/index.ts
@@ -1,6 +1,6 @@
 import layouts from '@mermaid-chart/layout-elk';
 import mermaid, { MermaidConfig } from '@mermaid-chart/mermaid';
-
+import { mermaidChartContainerSelector } from "../shared-md-mermaid";
 
 
 function renderMermaidElement(
@@ -43,8 +43,7 @@ function renderMermaidElement(
 }
 
 export async function renderMermaidBlocksInElement(root: HTMLElement, writeOut: (mermaidContainer: HTMLElement, content: string) => void): Promise<void> {
-    // Delete existing mermaid outputs
-    for (const el of Array.from(root.querySelectorAll('.mermaid > svg'))) {
+    for (const el of Array.from(root.querySelectorAll(`${mermaidChartContainerSelector} > svg`))) {
         el.remove();
     }
     for (const svg of Array.from(root.querySelectorAll('svg'))) {
@@ -55,7 +54,7 @@ export async function renderMermaidBlocksInElement(root: HTMLElement, writeOut: 
 
     // We need to generate all the container ids sync, but then do the actual rendering async
     const renderPromises: Array<Promise<void>> = [];
-    for (const mermaidContainer of Array.from(root.querySelectorAll<HTMLElement>('.mermaid'))) {
+    for (const mermaidContainer of Array.from(root.querySelectorAll<HTMLElement>(mermaidChartContainerSelector))) {
         renderPromises.push(renderMermaidElement(mermaidContainer, writeOut).p);
     }
 

--- a/src/previewmarkdown/themeing.ts
+++ b/src/previewmarkdown/themeing.ts
@@ -1,6 +1,7 @@
 import type MarkdownIt from 'markdown-it';
 import * as vscode from 'vscode';
 import { configSection } from '../util';
+import { prepareMermaidChartHtml } from './shared-md-mermaid';
 
 const defaultMermaidTheme = 'default';
 const validMermaidThemes = [
@@ -32,11 +33,12 @@ export function injectMermaidTheme(md: MarkdownIt) {
         const lightModeTheme = sanitizeMermaidTheme(config.get<string>('vscode.light'));
         const maxTextSize = config.get<number>('maxTextSize');
 
-        return `<span id="${configSection}" aria-hidden="true"
+        const html = `<span id="markdown-mermaid" aria-hidden="true"
                     data-dark-mode-theme="${darkModeTheme}"
                     data-light-mode-theme="${lightModeTheme}"
                     data-max-text-size="${maxTextSize}"></span>
                 ${render.apply(md.renderer, args)}`;
+        return prepareMermaidChartHtml(html);
     };
 
     return md;


### PR DESCRIPTION
## Summary

Fixes markdown preview Mermaid rendering when VS Code’s built-in mermaid extension conflicts with this extension’s renderer.

Both were targeting the same `<div class="mermaid">` elements in the preview webview, so diagrams could flash, fail on first open, or show duplicate errors.

This PR uses a dedicated container class (`mermaid-chart` instead of `mermaid`) so only our preview script renders those blocks. Built-in VS Code mermaid ignores `.mermaid-chart`, which removes the conflict and restores reliable rendering in markdown files.

