### PR TITLE
PLUG-73 Added Review Mermaid syn List Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-### 2.7.1 - 2026-06-18
+### 2.7.1 - 2026-06-22
 - Added **Mermaid Sync Review List** — sidebar listing all bot-updated diagrams with **M** / **A** / **R** badges, per-file accept/reject/close, and bulk **Accept All**, **Reject All**, **Close Review**, and **Open Changes** (login required for bulk actions).
 
 ### 2.7.0 - 2026-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 2.7.1 - 2026-06-18
+- Added **Mermaid Sync Review List** — sidebar listing all bot-updated diagrams with **M** / **A** / **R** badges, per-file accept/reject/close, and bulk **Accept All**, **Reject All**, **Close Review**, and **Open Changes** (login required for bulk actions).
+
 ### 2.7.0 - 2026-06-16
 - Added **Improve Diagram** — CodeLens commands at the top of .mmd / .mermaid files (**Preview Diagram**, **Save Diagram to Mermaid Chart**, **Repair Diagram**, **Improve Diagram**). 
 - **Improve Diagram** opens a sidebar view that generates two AI variants (layout/grouping and styling), with model selection, diff preview, and dual diagram previews before applying changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-### 2.7.1 - 2026-06-22
+### 2.7.1 - 2026-06-23
 - Added **Mermaid Sync Review List** — sidebar listing all bot-updated diagrams with **M** / **A** / **R** badges, per-file accept/reject/close, and bulk **Accept All**, **Reject All**, **Close Review**, and **Open Changes** (login required for bulk actions).
 
 ### 2.7.0 - 2026-06-16

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ This extension contributes the following settings:
 
 ## Release Notes
 
-### 2.7.1 - 2026-06-18
+### 2.7.1 - 2026-06-22
 - Added **Mermaid Sync Review List** — sidebar listing all bot-updated diagrams with **M** / **A** / **R** badges, per-file accept/reject/close, and bulk **Accept All**, **Reject All**, **Close Review**, and **Open Changes** (login required for bulk actions).
 
 ### 2.7.0 - 2026-06-16

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ This extension contributes the following settings:
 
 ## Release Notes
 
-### 2.7.1 - 2026-06-22
+### 2.7.1 - 2026-06-23
 - Added **Mermaid Sync Review List** — sidebar listing all bot-updated diagrams with **M** / **A** / **R** badges, per-file accept/reject/close, and bulk **Accept All**, **Reject All**, **Close Review**, and **Open Changes** (login required for bulk actions).
 
 ### 2.7.0 - 2026-06-16

--- a/README.md
+++ b/README.md
@@ -451,6 +451,37 @@ The **Review Changes** experience has been upgraded with a refreshed diagram dif
 
 ![vscode-plugin-review-diagram-diff-ui](https://mermaid.ai/docs/img/plugins/vscode-plugin-review-diagram-diff-ui.gif)
 
+### Mermaid Sync Review List
+
+When review is triggered (manually or after a `git pull` with Mermaid Sync updates), a **Review Mermaid Sync** view appears in the Mermaid activity bar. It lists every affected `.mmd` and `.mermaid` file in one place—so you can review all bot-driven diagram changes without opening the Explorer file by file.
+
+Each file shows a Git-style status badge:
+
+- **M** — Pending review / modified during review
+- **A** — Accepted
+- **R** — Rejected
+
+#### Per-file actions (from the sidebar)
+
+For each diagram in the list, you can:
+
+- **Accept** — Apply the bot's proposed content to the workspace file
+- **Reject** — Restore the pre-sync version
+- **Close** — Remove that file from the review session (without reverting content)
+- **Open the file** — Jump into the editor for the full review flow (diagram preview, diff, CodeLens options, etc.)
+
+#### Bulk actions (login required)
+
+The following bulk actions are gated behind **Mermaid Chart login**:
+
+- **Accept All** — Accept bot changes across every file in the review list
+- **Reject All** — Reject and restore all files in one step
+- **Close Review** — End the entire review session and clear the list
+- **Open Changes** — A Git-style unified changes view showing all diagram diffs in a single editor, so you can scan and compare every file without opening them one by one. Per-row accept/reject actions are also available in this view.
+
+
+![vscode-plugin-review-mermaid-sync-list](https://mermaid.ai/docs/img/plugins/vscode-plugin-review-mermaid-sync-list.gif)
+
 ### Diagram Diff Highlighting
 - **Enhanced Visual Clarity**: Our diagram diff previews now include advanced change highlighting to make differences even more visible and understandable.<br>
 - **Color-Coded Changes**:
@@ -514,6 +545,9 @@ This extension contributes the following settings:
 - `mermaid.vscode.aiExportName`: Determines whether to use GitHub Copilot to generate a name for the exported diagram.
 
 ## Release Notes
+
+### 2.7.1 - 2026-06-18
+- Added **Mermaid Sync Review List** — sidebar listing all bot-updated diagrams with **M** / **A** / **R** badges, per-file accept/reject/close, and bulk **Accept All**, **Reject All**, **Close Review**, and **Open Changes** (login required for bulk actions).
 
 ### 2.7.0 - 2026-06-16
 - Added **Improve Diagram** — CodeLens commands at the top of .mmd / .mermaid files (**Preview Diagram**, **Save Diagram to Mermaid Chart**, **Repair Diagram**, **Improve Diagram**). 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "MermaidChart",
   "displayName": "Mermaid",
   "description": "The official Mermaid Editor plugin by the Mermaid open source team, now with AI-powered diagramming! Create, edit and preview diagrams seamlessly within VS Code",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "icon": "images/mermaid-chart.png",
   "repository": "github:Mermaid-Chart/vscode-mermaid-chart",
   "engines": {
@@ -704,6 +704,11 @@
           "id": "mermaidImproveDiagram",
           "name": "Improve diagram",
           "type": "webview"
+        },
+        {
+          "id": "mermaidReviewSync",
+          "name": "Review Mermaid Sync",
+          "when": "mermaid.hasAppReviewSync"
         }
       ]
     },
@@ -723,9 +728,44 @@
           "command": "mermaidChart.diagramHelp",
           "when": "view == mermaidWebview",
           "group": "navigation"
+        },
+        {
+          "command": "mermaidChart.reviewSyncOpenChanges",
+          "when": "view == mermaidReviewSync",
+          "group": "navigation@1"
+        },
+        {
+          "command": "mermaidChart.reviewSyncRejectAll",
+          "when": "view == mermaidReviewSync",
+          "group": "navigation@2"
+        },
+        {
+          "command": "mermaidChart.reviewSyncAcceptAll",
+          "when": "view == mermaidReviewSync",
+          "group": "navigation@3"
+        },
+        {
+          "command": "mermaidChart.reviewSyncCloseAll",
+          "when": "view == mermaidReviewSync",
+          "group": "navigation@4"
         }
       ],
       "view/item/context": [
+        {
+          "command": "mermaidChart.appReviewAccept",
+          "when": "view == mermaidReviewSync && viewItem == mermaidReviewSyncFile",
+          "group": "inline@1"
+        },
+        {
+          "command": "mermaidChart.appReviewReject",
+          "when": "view == mermaidReviewSync && viewItem == mermaidReviewSyncFile",
+          "group": "inline@2"
+        },
+        {
+          "command": "mermaidChart.closeAppReview",
+          "when": "view == mermaidReviewSync && viewItem == mermaidReviewSyncFile",
+          "group": "inline@3"
+        },
         {
           "command": "mermaidChart.insertUuidIntoEditor",
           "when": "viewItem == document",
@@ -765,6 +805,23 @@
           "command": "mermaidChart.duplicateDiagram",
           "when": "viewItem == document",
           "group": "manage@03"
+        }
+      ],
+      "scm/resourceState/context": [
+        {
+          "command": "mermaidChart.appReviewAccept",
+          "when": "scmProvider == mermaidSyncReview",
+          "group": "inline@1"
+        },
+        {
+          "command": "mermaidChart.appReviewReject",
+          "when": "scmProvider == mermaidSyncReview",
+          "group": "inline@2"
+        },
+        {
+          "command": "mermaidChart.closeAppReview",
+          "when": "scmProvider == mermaidSyncReview",
+          "group": "inline@3"
         }
       ],
       "editor/context": [
@@ -924,6 +981,26 @@
         "title": "MermaidChart: Review Mermaid Sync"
       },
       {
+        "command": "mermaidChart.reviewSyncOpenChanges",
+        "title": "Open Changes",
+        "icon": "$(diff-multiple)"
+      },
+      {
+        "command": "mermaidChart.reviewSyncAcceptAll",
+        "title": "Accept All Changes",
+        "icon": "$(add)"
+      },
+      {
+        "command": "mermaidChart.reviewSyncRejectAll",
+        "title": "Reject All Changes",
+        "icon": "$(discard)"
+      },
+      {
+        "command": "mermaidChart.reviewSyncCloseAll",
+        "title": "Close Review",
+        "icon": "$(close)"
+      },
+      {
         "command": "mermaidChart.showAppSyncInfo",
         "title": "MermaidChart: Show App Sync Info"
       },
@@ -945,7 +1022,8 @@
       },
       {
         "command": "mermaidChart.closeAppReview",
-        "title": "MermaidChart: Close App Review (this file)"
+        "title": "Close Review",
+        "icon": "$(close)"
       },
       {
         "command": "mermaidChart.openAppReview",
@@ -957,11 +1035,13 @@
       },
       {
         "command": "mermaidChart.appReviewAccept",
-        "title": "MermaidChart: Accept App Review"
+        "title": "Accept",
+        "icon": "$(add)"
       },
       {
         "command": "mermaidChart.appReviewReject",
-        "title": "MermaidChart: Reject App Review"
+        "title": "Reject",
+        "icon": "$(discard)"
       },
       {
         "command": "mermaidChart.connectGitHub",
@@ -1204,6 +1284,7 @@
   },
   "packageManager": "pnpm@9.7.1+sha512.faf344af2d6ca65c4c5c8c2224ea77a81a5e8859cbc4e06b1511ddce2f0151512431dd19e6aff31f2c6a8f5f2aced9bd2273e1fed7dd4de1868984059d2c4247",
   "enabledApiProposals": [
-    "languageModelToolsForAgent"
+    "languageModelToolsForAgent",
+    "scmProviderOptions"
   ]
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -68,6 +68,27 @@ class Analytics {
     );
   }
 
+  public trackReviewSyncOpenChanges() {
+    this.sendEvent(
+      "VS Code Mermaid Sync Review Open Changes",
+      "VS_CODE_PLUGIN_MERMAID_SYNC_REVIEW_OPEN_CHANGES",
+    );
+  }
+
+  public trackReviewSyncAcceptAll() {
+    this.sendEvent(
+      "VS Code Mermaid Sync Review Accept All",
+      "VS_CODE_PLUGIN_MERMAID_SYNC_REVIEW_ACCEPT_ALL",
+    );
+  }
+
+  public trackReviewSyncRejectAll() {
+    this.sendEvent(
+      "VS Code Mermaid Sync Review Reject All",
+      "VS_CODE_PLUGIN_MERMAID_SYNC_REVIEW_REJECT_ALL",
+    );
+  }
+
   // Generate diagram from code
   public trackOpenCopilotChat() {
     this.sendEvent(

--- a/src/appDiffViewProvider.ts
+++ b/src/appDiffViewProvider.ts
@@ -28,10 +28,27 @@ function fileUrisMatch(a: vscode.Uri, b: vscode.Uri, integration: AppReviewInteg
  */
 type AppCodeDiffSession = {
   originalTempUri: vscode.Uri;
-  incomingTempUri: vscode.Uri;
-  incomingKey: string;
+  /** Right side of the diff — the real workspace diagram file. */
+  modifiedUri: vscode.Uri;
+  sessionDirUri: vscode.Uri;
   saveDisposable: vscode.Disposable;
   tabCloseDisposable: vscode.Disposable;
+  cleaned: boolean;
+};
+
+type AppMultiDiffEntry = {
+  originalFilePath: string;
+  originalTempUri: vscode.Uri;
+  modifiedUri: vscode.Uri;
+};
+
+type AppMultiDiffSession = {
+  title: string;
+  sessionDirUri: vscode.Uri;
+  multiDiffSourceUri?: vscode.Uri;
+  entries: AppMultiDiffEntry[];
+  disposables: vscode.Disposable;
+  onClosed?: () => void;
   cleaned: boolean;
 };
 
@@ -52,6 +69,8 @@ type AppReviewPanelSession = {
  */
 export class AppDiffViewProvider {
   private readonly sessionsByOriginal = new Map<string, AppReviewPanelSession>();
+  private readonly diffSaveByPath = new Map<string, vscode.Disposable>();
+  private multiDiffSession: AppMultiDiffSession | null = null;
 
   constructor(
     private readonly appReviewIntegration: AppReviewIntegration,
@@ -198,6 +217,105 @@ export class AppDiffViewProvider {
   }
 
   /**
+   * Diff pair for {@link openCodeDiff} and {@link openAllReviewChanges}:
+   * left = PR-base snapshot (temp), right = live workspace file (same as Git Changes).
+   */
+  private reviewTempBaseName(relativePath: string): string {
+    const hash = crypto.createHash("sha256").update(relativePath).digest("hex").slice(0, 12);
+    const baseName = path.basename(relativePath).replace(/[^a-zA-Z0-9._-]/g, "_");
+    return `${hash}__${baseName}.base.mmd`;
+  }
+
+  private async prepareCodeDiffPair(
+    mapping: ReviewFileMapping,
+    sessionDir: string,
+  ): Promise<{ originalTempUri: vscode.Uri; modifiedUri: vscode.Uri }> {
+    const originalTempUri = vscode.Uri.file(
+      path.join(sessionDir, this.reviewTempBaseName(mapping.relativePath)),
+    );
+    const modifiedUri = vscode.Uri.file(mapping.originalFilePath);
+
+    await vscode.workspace.fs.writeFile(
+      originalTempUri,
+      Buffer.from(mapping.originalContent, "utf8"),
+    );
+
+    return { originalTempUri, modifiedUri };
+  }
+
+  private applyIncomingDiffSave(
+    originalFilePath: string,
+    text: string,
+    panelSession?: AppReviewPanelSession,
+  ): void {
+    const mapping = this.appReviewIntegration.getReviewMapping(originalFilePath);
+    if (!mapping) {
+      return;
+    }
+    void (async () => {
+      try {
+        await this.replaceOriginalFileContent(originalFilePath, text);
+        mapping.appContent = text;
+        mapping.status = "modified";
+        this.fileDecorationProvider.updateFileStatus(originalFilePath, "modified");
+        this.appReviewIntegration.notifyReviewMappingsChanged();
+        if (panelSession) {
+          void this.refreshReviewPanel(panelSession);
+        }
+      } catch (err) {
+        vscode.window.showErrorMessage(`Could not save to diagram file: ${err}`);
+      }
+    })();
+  }
+
+  private wireCodeDiffSave(
+    modifiedUri: vscode.Uri,
+    originalFilePath: string,
+    panelSession?: AppReviewPanelSession,
+  ): vscode.Disposable {
+    const key = path.normalize(originalFilePath);
+    this.diffSaveByPath.get(key)?.dispose();
+
+    const listener = vscode.workspace.onDidSaveTextDocument((saved) => {
+      if (!fileUrisMatch(saved.uri, modifiedUri, this.appReviewIntegration)) {
+        return;
+      }
+      this.applyIncomingDiffSave(originalFilePath, saved.getText(), panelSession);
+    });
+    this.diffSaveByPath.set(key, listener);
+
+    return new vscode.Disposable(() => {
+      listener.dispose();
+      if (this.diffSaveByPath.get(key) === listener) {
+        this.diffSaveByPath.delete(key);
+      }
+    });
+  }
+
+  private async buildReviewChangesResources(
+    mappings: ReviewFileMapping[],
+    sessionDir: string,
+  ): Promise<{
+    resources: [vscode.Uri, vscode.Uri, vscode.Uri][];
+    entries: AppMultiDiffEntry[];
+  }> {
+    const resources: [vscode.Uri, vscode.Uri, vscode.Uri][] = [];
+    const entries: AppMultiDiffEntry[] = [];
+
+    for (const mapping of mappings) {
+      const { originalTempUri, modifiedUri } = await this.prepareCodeDiffPair(mapping, sessionDir);
+      resources.push([modifiedUri, originalTempUri, modifiedUri]);
+      entries.push({
+        originalFilePath: mapping.originalFilePath,
+        originalTempUri,
+        modifiedUri,
+      });
+    }
+
+    return { resources, entries };
+  }
+
+  /**
    * Opens (or focuses) native vscode.diff for app review — PLUG-72 flow, on demand from Diff code.
    */
   async openCodeDiff(fileUri: vscode.Uri): Promise<void> {
@@ -208,25 +326,15 @@ export class AppDiffViewProvider {
     }
 
     const panelSession = this.sessionsByOriginal.get(path.normalize(mapping.originalFilePath));
-    const currentContent = await this.readCurrentWorkspaceContent(mapping.originalFilePath);
+    const modifiedUri = vscode.Uri.file(mapping.originalFilePath);
 
     if (panelSession?.codeDiff && !panelSession.codeDiff.cleaned) {
       const codeDiff = panelSession.codeDiff;
-      try {
-        await vscode.workspace.fs.writeFile(
-          codeDiff.incomingTempUri,
-          Buffer.from(currentContent, "utf8"),
-        );
-      } catch (e) {
-        vscode.window.showErrorMessage(`Could not refresh review diff: ${e}`);
-        return;
-      }
-
       const diffTitle = `App review: ${path.basename(mapping.originalFilePath)}`;
       await vscode.commands.executeCommand(
         "vscode.diff",
         codeDiff.originalTempUri,
-        codeDiff.incomingTempUri,
+        modifiedUri,
         diffTitle,
         { preview: false, viewColumn: vscode.ViewColumn.Beside },
       );
@@ -242,54 +350,26 @@ export class AppDiffViewProvider {
       /* exists */
     }
 
-    const safeBase = path.basename(mapping.originalFilePath).replace(/[^a-zA-Z0-9._-]/g, "_");
-    const originalTempUri = vscode.Uri.file(path.join(sessionDir, `${safeBase}.base.mmd`));
-    const incomingTempUri = vscode.Uri.file(path.join(sessionDir, `${safeBase}.incoming.mmd`));
-    const incomingKey = path.normalize(incomingTempUri.fsPath);
-
+    let originalTempUri: vscode.Uri;
     try {
-      await vscode.workspace.fs.writeFile(
-        originalTempUri,
-        Buffer.from(mapping.originalContent, "utf8"),
-      );
-      await vscode.workspace.fs.writeFile(
-        incomingTempUri,
-        Buffer.from(currentContent, "utf8"),
-      );
+      ({ originalTempUri } = await this.prepareCodeDiffPair(mapping, sessionDir));
     } catch (e) {
       vscode.window.showErrorMessage(`Could not create temp review files: ${e}`);
       return;
     }
 
     const diffTitle = `App review: ${path.basename(mapping.originalFilePath)}`;
-    await vscode.commands.executeCommand("vscode.diff", originalTempUri, incomingTempUri, diffTitle, {
+    await vscode.commands.executeCommand("vscode.diff", originalTempUri, modifiedUri, diffTitle, {
       preview: false,
       viewColumn: vscode.ViewColumn.Beside,
     });
 
-    const saveDisposable = vscode.workspace.onDidSaveTextDocument(async (saved) => {
-      if (!fileUrisMatch(saved.uri, incomingTempUri, this.appReviewIntegration)) {
-        return;
-      }
-      try {
-        const text = saved.getText();
-        await this.replaceOriginalFileContent(mapping.originalFilePath, text);
-        mapping.appContent = text;
-        mapping.status = "modified";
-        this.fileDecorationProvider.updateFileStatus(mapping.originalFilePath, "modified");
-        this.appReviewIntegration.notifyReviewMappingsChanged();
-        if (panelSession) {
-          void this.refreshReviewPanel(panelSession);
-        }
-      } catch (err) {
-        vscode.window.showErrorMessage(`Could not save to diagram file: ${err}`);
-      }
-    });
+    const saveDisposable = this.wireCodeDiffSave(modifiedUri, mapping.originalFilePath, panelSession);
 
     const codeDiffSession: AppCodeDiffSession = {
       originalTempUri,
-      incomingTempUri,
-      incomingKey,
+      modifiedUri,
+      sessionDirUri,
       saveDisposable,
       tabCloseDisposable: vscode.window.tabGroups.onDidChangeTabs(({ closed }) => {
         for (const tab of closed) {
@@ -297,7 +377,7 @@ export class AppDiffViewProvider {
             const { original, modified } = tab.input;
             if (
               fileUrisMatch(original, originalTempUri, this.appReviewIntegration) &&
-              fileUrisMatch(modified, incomingTempUri, this.appReviewIntegration)
+              fileUrisMatch(modified, modifiedUri, this.appReviewIntegration)
             ) {
               void this.cleanupCodeDiffSession(panelSession, codeDiffSession);
               return;
@@ -310,6 +390,137 @@ export class AppDiffViewProvider {
 
     if (panelSession) {
       panelSession.codeDiff = codeDiffSession;
+    }
+  }
+
+  /**
+   * Git-style unified changes editor — reuses {@link prepareCodeDiffPair} (same as Diff code).
+   */
+  async openAllReviewChanges(options: {
+    multiDiffSourceUri?: vscode.Uri;
+    onMultiDiffClosed?: () => void;
+  } = {}): Promise<void> {
+    const { multiDiffSourceUri, onMultiDiffClosed } = options;
+    const mappings = [...this.appReviewIntegration.getReviewMappings().values()].sort((a, b) =>
+      a.relativePath.localeCompare(b.relativePath),
+    );
+    if (mappings.length === 0) {
+      vscode.window.showInformationMessage("No diagrams in review.");
+      return;
+    }
+
+    await this.cleanupMultiDiffSession();
+
+    const id = crypto.randomBytes(8).toString("hex");
+    const sessionDir = path.join(os.tmpdir(), "vscode-mermaid-chart-app-review-multi", id);
+    const sessionDirUri = vscode.Uri.file(sessionDir);
+    try {
+      await vscode.workspace.fs.createDirectory(sessionDirUri);
+    } catch {
+      /* exists */
+    }
+
+    let resources: [vscode.Uri, vscode.Uri, vscode.Uri][];
+    let entries: AppMultiDiffEntry[];
+
+    try {
+      ({ resources, entries } = await this.buildReviewChangesResources(mappings, sessionDir));
+    } catch (e) {
+      vscode.window.showErrorMessage(`Could not prepare review changes: ${e}`);
+      onMultiDiffClosed?.();
+      try {
+        await vscode.workspace.fs.delete(sessionDirUri, { recursive: true });
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+
+    const title = `Mermaid Sync: Changes (${mappings.length} files)`;
+
+    const multiDiffResources = resources.map(([, originalUri, modifiedUri]) => ({
+      originalUri,
+      modifiedUri,
+    }));
+
+    try {
+      await vscode.commands.executeCommand("_workbench.openMultiDiffEditor", {
+        title,
+        multiDiffSourceUri,
+        resources: multiDiffResources,
+      });
+    } catch {
+      try {
+        await vscode.commands.executeCommand("vscode.changes", title, resources);
+      } catch (e) {
+        vscode.window.showErrorMessage(
+          `Could not open changes view. Update VS Code or open diffs from each file. ${e}`,
+        );
+        onMultiDiffClosed?.();
+        try {
+          await vscode.workspace.fs.delete(sessionDirUri, { recursive: true });
+        } catch {
+          /* ignore */
+        }
+        return;
+      }
+    }
+
+    const saveDisposables = entries.map((entry) => {
+      const panelSession = this.sessionsByOriginal.get(path.normalize(entry.originalFilePath));
+      return this.wireCodeDiffSave(entry.modifiedUri, entry.originalFilePath, panelSession);
+    });
+
+    const tabCloseDisposable = vscode.window.tabGroups.onDidChangeTabs(({ closed }) => {
+      for (const tab of closed) {
+        if (this.isOurMultiDiffTab(tab, multiDiffSourceUri, title)) {
+          void this.cleanupMultiDiffSession();
+          return;
+        }
+      }
+    });
+
+    this.multiDiffSession = {
+      title,
+      sessionDirUri,
+      multiDiffSourceUri,
+      entries,
+      disposables: vscode.Disposable.from(...saveDisposables, tabCloseDisposable),
+      onClosed: onMultiDiffClosed,
+      cleaned: false,
+    };
+  }
+
+  private isOurMultiDiffTab(
+    tab: vscode.Tab,
+    multiDiffSourceUri: vscode.Uri | undefined,
+    title: string,
+  ): boolean {
+    const input = tab.input as { multiDiffSource?: vscode.Uri } | undefined;
+    if (
+      multiDiffSourceUri &&
+      input &&
+      input.multiDiffSource instanceof vscode.Uri &&
+      input.multiDiffSource.toString() === multiDiffSourceUri.toString()
+    ) {
+      return true;
+    }
+    return tab.label === title || tab.label.startsWith("Mermaid Sync: Changes");
+  }
+
+  async cleanupMultiDiffSession(): Promise<void> {
+    const session = this.multiDiffSession;
+    if (!session || session.cleaned) {
+      return;
+    }
+    session.cleaned = true;
+    this.multiDiffSession = null;
+    session.disposables.dispose();
+    session.onClosed?.();
+    try {
+      await vscode.workspace.fs.delete(session.sessionDirUri, { recursive: true });
+    } catch {
+      /* ignore */
     }
   }
 
@@ -326,45 +537,12 @@ export class AppDiffViewProvider {
       panelSession.codeDiff = undefined;
     }
 
-    let contentToApply: string | undefined;
     try {
-      try {
-        await vscode.workspace.fs.stat(codeDiff.incomingTempUri);
-        const rightDoc = await vscode.workspace.openTextDocument(codeDiff.incomingTempUri);
-        if (rightDoc.isDirty) {
-          vscode.window.showInformationMessage(
-            "App review diff closed with unsaved changes on the right.",
-          );
-        } else {
-          contentToApply = rightDoc.getText();
-        }
-      } catch {
-        /* temp gone */
-      }
-    } finally {
       codeDiff.saveDisposable.dispose();
       codeDiff.tabCloseDisposable.dispose();
-      try {
-        await vscode.workspace.fs.delete(
-          vscode.Uri.file(path.dirname(codeDiff.incomingTempUri.fsPath)),
-          { recursive: true },
-        );
-      } catch {
-        /* ignore */
-      }
-    }
-
-    if (contentToApply !== undefined && panelSession) {
-      try {
-        await this.replaceOriginalFileContent(panelSession.mapping.originalFilePath, contentToApply);
-        panelSession.mapping.appContent = contentToApply;
-        panelSession.mapping.status = "modified";
-        this.fileDecorationProvider.updateFileStatus(panelSession.mapping.originalFilePath, "modified");
-        this.appReviewIntegration.notifyReviewMappingsChanged();
-        void this.refreshReviewPanel(panelSession);
-      } catch (err) {
-        vscode.window.showErrorMessage(`Failed to apply changes on diff close: ${err}`);
-      }
+      await vscode.workspace.fs.delete(codeDiff.sessionDirUri, { recursive: true });
+    } catch {
+      /* ignore */
     }
   }
 
@@ -410,49 +588,72 @@ export class AppDiffViewProvider {
     }
   }
 
-  async acceptAppChanges(fileUri: vscode.Uri): Promise<void> {
+  async acceptAppChanges(
+    fileUri: vscode.Uri,
+    options: { silent?: boolean; notify?: boolean } = {},
+  ): Promise<boolean> {
     const mapping = this.appReviewIntegration.getReviewMapping(fileUri.fsPath);
     if (!mapping) {
-      return;
+      return false;
     }
     try {
       await this.cancelSessionsForOriginal(mapping.originalFilePath);
       await this.replaceOriginalFileContent(mapping.originalFilePath, mapping.appContent);
       mapping.status = "accepted";
       this.fileDecorationProvider.updateFileStatus(mapping.originalFilePath, "accepted");
-      this.appReviewIntegration.notifyReviewMappingsChanged();
-      const doc = await vscode.workspace.openTextDocument(mapping.originalFilePath);
-      await vscode.window.showTextDocument(doc);
-      vscode.window.showInformationMessage(
-        `App changes applied to ${path.basename(mapping.originalFilePath)}`
-      );
+      if (options.notify !== false) {
+        this.appReviewIntegration.notifyReviewMappingsChanged();
+      }
+      if (!options.silent) {
+        const doc = await vscode.workspace.openTextDocument(mapping.originalFilePath);
+        await vscode.window.showTextDocument(doc);
+        vscode.window.showInformationMessage(
+          `App changes applied to ${path.basename(mapping.originalFilePath)}`
+        );
+      }
+      return true;
     } catch (error) {
-      vscode.window.showErrorMessage(`Error accepting app changes: ${error}`);
+      if (!options.silent) {
+        vscode.window.showErrorMessage(`Error accepting app changes: ${error}`);
+      }
+      return false;
     }
   }
 
-  async rejectAppChanges(fileUri: vscode.Uri): Promise<void> {
+  async rejectAppChanges(
+    fileUri: vscode.Uri,
+    options: { silent?: boolean; notify?: boolean } = {},
+  ): Promise<boolean> {
     const mapping = this.appReviewIntegration.getReviewMapping(fileUri.fsPath);
     if (!mapping) {
-      return;
+      return false;
     }
     try {
       await this.cancelSessionsForOriginal(mapping.originalFilePath);
       await this.replaceOriginalFileContent(mapping.originalFilePath, mapping.originalContent);
       mapping.status = "rejected";
       this.fileDecorationProvider.updateFileStatus(mapping.originalFilePath, "rejected");
-      this.appReviewIntegration.notifyReviewMappingsChanged();
-      const doc = await vscode.workspace.openTextDocument(mapping.originalFilePath);
-      await vscode.window.showTextDocument(doc);
-      vscode.window.showInformationMessage(
-        `${path.basename(mapping.originalFilePath)}: restored to the version from before the Mermaid Sync app update.`
-      );
+      if (options.notify !== false) {
+        this.appReviewIntegration.notifyReviewMappingsChanged();
+      }
+      if (!options.silent) {
+        const doc = await vscode.workspace.openTextDocument(mapping.originalFilePath);
+        await vscode.window.showTextDocument(doc);
+        vscode.window.showInformationMessage(
+          `${path.basename(mapping.originalFilePath)}: restored to the version from before the Mermaid Sync app update.`
+        );
+      }
+      return true;
     } catch (error) {
-      vscode.window.showErrorMessage(`Error rejecting app changes: ${error}`);
+      if (!options.silent) {
+        vscode.window.showErrorMessage(`Error rejecting app changes: ${error}`);
+      }
+      return false;
     }
   }
 
   dispose(): void {
+    void this.cleanupMultiDiffSession();
     for (const session of [...this.sessionsByOriginal.values()]) {
       if (session.codeDiff && !session.codeDiff.cleaned) {
         session.codeDiff.saveDisposable.dispose();

--- a/src/appFileDecorationProvider.ts
+++ b/src/appFileDecorationProvider.ts
@@ -6,8 +6,9 @@ import {
   relativePathFromAbsolute,
   repoRelativeParentDir,
 } from "./appReviewPaths";
+import { reviewStatusDecoration, toReviewTreeUri, fsPathFromReviewUri } from "./appReviewStatus";
 
-/** Purple tint in the explorer for in-review files and their parent folders (no badge/icons on names). */
+/** Purple tint for parent folders that contain in-review diagram files. */
 const REVIEW_PURPLE = new vscode.ThemeColor("charts.purple");
 
 export class AppFileDecorationProvider implements vscode.FileDecorationProvider {
@@ -62,12 +63,28 @@ export class AppFileDecorationProvider implements vscode.FileDecorationProvider 
   }
 
   provideFileDecoration(uri: vscode.Uri): vscode.FileDecoration | undefined {
+    const reviewTreePath = fsPathFromReviewUri(uri);
+    if (reviewTreePath) {
+      const mapping = this.appReviewIntegration.getReviewMapping(reviewTreePath);
+      if (mapping) {
+        const status = reviewStatusDecoration(mapping.status);
+        return {
+          badge: status.badge,
+          color: status.color,
+          tooltip: this.fileTooltip(mapping),
+          propagate: false,
+        };
+      }
+      return undefined;
+    }
+
     if (uri.scheme !== "file") {
       return undefined;
     }
 
     const mapping = this.appReviewIntegration.getReviewMapping(uri.fsPath);
     if (mapping) {
+      // Explorer: purple tint only — badges live on the Review Mermaid Sync tree (custom URI).
       return {
         color: REVIEW_PURPLE,
         tooltip: this.fileTooltip(mapping),
@@ -97,13 +114,14 @@ export class AppFileDecorationProvider implements vscode.FileDecorationProvider 
 
   refresh(): void {
     this.parentFolderToMappings = null;
-    const parentDirs = new Set<string>();
+    const uris: vscode.Uri[] = [];
     for (const mapping of this.appReviewIntegration.getReviewMappings().values()) {
-      this._onDidChangeFileDecorations.fire(vscode.Uri.file(mapping.originalFilePath));
-      parentDirs.add(path.dirname(mapping.originalFilePath));
+      uris.push(vscode.Uri.file(mapping.originalFilePath));
+      uris.push(toReviewTreeUri(mapping.originalFilePath));
+      uris.push(vscode.Uri.file(path.dirname(mapping.originalFilePath)));
     }
-    for (const parentDir of parentDirs) {
-      this._onDidChangeFileDecorations.fire(vscode.Uri.file(parentDir));
+    for (const uri of uris) {
+      this._onDidChangeFileDecorations.fire(uri);
     }
     this._onDidChangeFileDecorations.fire(undefined);
   }
@@ -118,6 +136,7 @@ export class AppFileDecorationProvider implements vscode.FileDecorationProvider 
       this.parentFolderToMappings = null;
       const uri = vscode.Uri.file(mapping.originalFilePath);
       this._onDidChangeFileDecorations.fire(uri);
+      this._onDidChangeFileDecorations.fire(toReviewTreeUri(mapping.originalFilePath));
       this._onDidChangeFileDecorations.fire(
         vscode.Uri.file(path.dirname(mapping.originalFilePath))
       );

--- a/src/appReviewFeature.ts
+++ b/src/appReviewFeature.ts
@@ -9,6 +9,7 @@ import { AppReviewGitPullWatcher } from "./appReviewGitPullWatcher";
 import { ReviewMermaidSyncTreeProvider } from "./reviewMermaidSyncTreeProvider";
 import { MermaidChartAuthenticationProvider } from "./mermaidChartAuthenticationProvider";
 import { AppReviewScmSync, resolveReviewCommandTarget } from "./appReviewScmSync";
+import analytics from "./analytics";
 
 /**
  * Facade that owns all app review sub-components and wires them together.
@@ -123,6 +124,7 @@ export class AppReviewFeature implements vscode.Disposable {
 
     this.integration.notifyReviewMappingsChanged();
     if (accepted > 0) {
+      analytics.trackReviewSyncAcceptAll();
       vscode.window.showInformationMessage(
         `Accepted Mermaid Sync changes for ${accepted} diagram file(s).`,
       );
@@ -162,6 +164,7 @@ export class AppReviewFeature implements vscode.Disposable {
 
     this.integration.notifyReviewMappingsChanged();
     if (rejected > 0) {
+      analytics.trackReviewSyncRejectAll();
       vscode.window.showInformationMessage(
         `Rejected Mermaid Sync changes for ${rejected} diagram file(s).`,
       );
@@ -179,10 +182,16 @@ export class AppReviewFeature implements vscode.Disposable {
       return;
     }
 
+    if (this.integration.getReviewMappings().size === 0) {
+      vscode.window.showInformationMessage("No diagrams in review.");
+      return;
+    }
+
     await this.diffViewProvider.openAllReviewChanges({
       multiDiffSourceUri: this.reviewScmSync.ensureForMultiDiff(),
       onMultiDiffClosed: () => this.reviewScmSync.releaseMultiDiff(),
     });
+    analytics.trackReviewSyncOpenChanges();
   }
 
   private async closeAllInReview(): Promise<void> {

--- a/src/appReviewFeature.ts
+++ b/src/appReviewFeature.ts
@@ -6,6 +6,9 @@ import { AppDiffViewProvider } from "./appDiffViewProvider";
 import { AppReviewCodeLensProvider } from "./appReviewCodeLensProvider";
 import { AppCommitWorkflow } from "./appCommitWorkflow";
 import { AppReviewGitPullWatcher } from "./appReviewGitPullWatcher";
+import { ReviewMermaidSyncTreeProvider } from "./reviewMermaidSyncTreeProvider";
+import { MermaidChartAuthenticationProvider } from "./mermaidChartAuthenticationProvider";
+import { AppReviewScmSync, resolveReviewCommandTarget } from "./appReviewScmSync";
 
 /**
  * Facade that owns all app review sub-components and wires them together.
@@ -19,23 +22,196 @@ export class AppReviewFeature implements vscode.Disposable {
   private readonly codeLensProvider: AppReviewCodeLensProvider;
   private readonly commitWorkflow: AppCommitWorkflow;
   private readonly gitPullWatcher: AppReviewGitPullWatcher;
+  private readonly reviewSyncTree: ReviewMermaidSyncTreeProvider;
+  private readonly reviewScmSync: AppReviewScmSync;
 
   constructor() {
     this.integration = new AppReviewIntegration();
+    this.reviewScmSync = new AppReviewScmSync(this.integration);
     this.gitStatusTracker = new AppReviewGitStatusTracker(this.integration);
     this.fileDecorationProvider = new AppFileDecorationProvider(this.integration);
     this.diffViewProvider = new AppDiffViewProvider(this.integration, this.fileDecorationProvider);
     this.codeLensProvider = new AppReviewCodeLensProvider(this.integration, this.gitStatusTracker);
     this.commitWorkflow = new AppCommitWorkflow(this.integration, this.gitStatusTracker);
-    this.gitPullWatcher = new AppReviewGitPullWatcher(this.integration);
+    this.reviewSyncTree = new ReviewMermaidSyncTreeProvider(this.integration);
+    this.gitPullWatcher = new AppReviewGitPullWatcher(this.integration, (count) =>
+      this.focusReviewSyncPanel(count),
+    );
+  }
+
+  private resolveReviewTarget(
+    arg?: vscode.Uri | vscode.TreeItem | vscode.SourceControlResourceState,
+  ): vscode.Uri | undefined {
+    return (
+      resolveReviewCommandTarget(arg) ??
+      resolveReviewCommandTarget(vscode.window.activeTextEditor?.document.uri)
+    );
+  }
+
+  private refreshReviewScmIfOpen(): void {
+    this.reviewScmSync.refreshIfActive();
   }
 
   register(context: vscode.ExtensionContext): void {
+    this.reviewSyncTree.register(context);
     this.registerProviders(context);
     this.registerCommands(context);
     this.registerEventListeners(context);
+    context.subscriptions.push(this.reviewScmSync);
     this.gitPullWatcher.start(context);
-    context.subscriptions.push(this);
+  }
+
+  private async focusReviewSyncPanel(registeredCount: number): Promise<void> {
+    if (registeredCount <= 0) {
+      return;
+    }
+    await this.reviewSyncTree.focusView();
+  }
+
+  private async ensureMermaidLogin(): Promise<boolean> {
+    const session = await vscode.authentication.getSession(
+      MermaidChartAuthenticationProvider.id,
+      [],
+      { silent: true },
+    );
+    if (session) {
+      return true;
+    }
+
+    const pick = await vscode.window.showInformationMessage(
+      "Sign in to Mermaid Chart to use Review Mermaid Sync actions.",
+      { modal: true },
+      "Sign in",
+    );
+    if (pick !== "Sign in") {
+      return false;
+    }
+
+    await vscode.commands.executeCommand("mermaidChart.login");
+    const afterLogin = await vscode.authentication.getSession(
+      MermaidChartAuthenticationProvider.id,
+      [],
+      { silent: true },
+    );
+    return !!afterLogin;
+  }
+
+  private async acceptAllInReview(): Promise<void> {
+    if (!(await this.ensureMermaidLogin())) {
+      return;
+    }
+
+    const all = [...this.integration.getReviewMappings().values()];
+    if (all.length === 0) {
+      vscode.window.showInformationMessage("No diagrams in review.");
+      return;
+    }
+
+    let accepted = 0;
+    let failed = 0;
+    for (const mapping of all) {
+      const ok = await this.diffViewProvider.acceptAppChanges(
+        vscode.Uri.file(mapping.originalFilePath),
+        { silent: true, notify: false },
+      );
+      if (ok) {
+        accepted++;
+      } else {
+        failed++;
+      }
+    }
+
+    this.integration.notifyReviewMappingsChanged();
+    if (accepted > 0) {
+      vscode.window.showInformationMessage(
+        `Accepted Mermaid Sync changes for ${accepted} diagram file(s).`,
+      );
+    }
+    if (failed > 0) {
+      vscode.window.showErrorMessage(
+        `Could not accept Mermaid Sync changes for ${failed} diagram file(s).`,
+      );
+    }
+    this.reviewSyncTree.refresh();
+  }
+
+  private async rejectAllInReview(): Promise<void> {
+    if (!(await this.ensureMermaidLogin())) {
+      return;
+    }
+
+    const all = [...this.integration.getReviewMappings().values()];
+    if (all.length === 0) {
+      vscode.window.showInformationMessage("No diagrams in review.");
+      return;
+    }
+
+    let rejected = 0;
+    let failed = 0;
+    for (const mapping of all) {
+      const ok = await this.diffViewProvider.rejectAppChanges(
+        vscode.Uri.file(mapping.originalFilePath),
+        { silent: true, notify: false },
+      );
+      if (ok) {
+        rejected++;
+      } else {
+        failed++;
+      }
+    }
+
+    this.integration.notifyReviewMappingsChanged();
+    if (rejected > 0) {
+      vscode.window.showInformationMessage(
+        `Rejected Mermaid Sync changes for ${rejected} diagram file(s).`,
+      );
+    }
+    if (failed > 0) {
+      vscode.window.showErrorMessage(
+        `Could not reject Mermaid Sync changes for ${failed} diagram file(s).`,
+      );
+    }
+    this.reviewSyncTree.refresh();
+  }
+
+  private async openChangesInReview(): Promise<void> {
+    if (!(await this.ensureMermaidLogin())) {
+      return;
+    }
+
+    await this.diffViewProvider.openAllReviewChanges({
+      multiDiffSourceUri: this.reviewScmSync.ensureForMultiDiff(),
+      onMultiDiffClosed: () => this.reviewScmSync.releaseMultiDiff(),
+    });
+  }
+
+  private async closeAllInReview(): Promise<void> {
+    if (!(await this.ensureMermaidLogin())) {
+      return;
+    }
+
+    const mappings = [...this.integration.getReviewMappings().values()];
+    if (mappings.length === 0) {
+      vscode.window.showInformationMessage("No active review session.");
+      return;
+    }
+
+    for (const mapping of mappings) {
+      await this.diffViewProvider.cancelSessionsForOriginal(mapping.originalFilePath);
+      this.gitStatusTracker.invalidatePath(mapping.originalFilePath);
+    }
+
+    await this.diffViewProvider.cleanupMultiDiffSession();
+    this.reviewScmSync.releaseMultiDiff();
+
+    const count = this.integration.clearAllReviews();
+    this.fileDecorationProvider.refresh();
+    this.codeLensProvider.refresh();
+    this.reviewSyncTree.refresh();
+
+    if (count > 0) {
+      vscode.window.showInformationMessage(`Closed Mermaid Sync review for ${count} diagram file(s).`);
+    }
   }
 
   private registerProviders(context: vscode.ExtensionContext): void {
@@ -64,8 +240,21 @@ export class AppReviewFeature implements vscode.Disposable {
 
   private registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
-      vscode.commands.registerCommand("mermaidChart.reviewAppCommits", () =>
-        this.integration.reviewAppCommits()
+      vscode.commands.registerCommand("mermaidChart.reviewAppCommits", async () => {
+        const count = await this.integration.reviewAppCommits();
+        await this.focusReviewSyncPanel(count);
+      }),
+      vscode.commands.registerCommand("mermaidChart.reviewSyncOpenChanges", () =>
+        this.openChangesInReview(),
+      ),
+      vscode.commands.registerCommand("mermaidChart.reviewSyncAcceptAll", () =>
+        this.acceptAllInReview(),
+      ),
+      vscode.commands.registerCommand("mermaidChart.reviewSyncRejectAll", () =>
+        this.rejectAllInReview(),
+      ),
+      vscode.commands.registerCommand("mermaidChart.reviewSyncCloseAll", () =>
+        this.closeAllInReview(),
       ),
       vscode.commands.registerCommand("mermaidChart.connectGitHub", () =>
         this.integration.connectGitHub()
@@ -85,30 +274,30 @@ export class AppReviewFeature implements vscode.Disposable {
       vscode.commands.registerCommand("mermaidChart.acceptModifiedChanges", (uri: vscode.Uri) =>
         this.codeLensProvider.acceptModifiedChanges(uri)
       ),
-      vscode.commands.registerCommand("mermaidChart.openReviewFileDiff", async (uri?: vscode.Uri) => {
-        const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      vscode.commands.registerCommand("mermaidChart.openReviewFileDiff", async (arg) => {
+        const target = this.resolveReviewTarget(arg);
         if (!target) {
           vscode.window.showWarningMessage("Open a diagram file (.mmd) to review changes.");
           return;
         }
         await this.diffViewProvider.showAppDiff(target);
       }),
-      vscode.commands.registerCommand("mermaidChart.appReviewAccept", async (uri?: vscode.Uri) => {
-        const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      vscode.commands.registerCommand("mermaidChart.appReviewAccept", async (arg) => {
+        const target = this.resolveReviewTarget(arg);
         if (target) {
           await this.diffViewProvider.acceptAppChanges(target);
           await this.gitStatusTracker.refreshPath(target.fsPath);
         }
       }),
-      vscode.commands.registerCommand("mermaidChart.appReviewReject", async (uri?: vscode.Uri) => {
-        const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      vscode.commands.registerCommand("mermaidChart.appReviewReject", async (arg) => {
+        const target = this.resolveReviewTarget(arg);
         if (target) {
           await this.diffViewProvider.rejectAppChanges(target);
           await this.gitStatusTracker.refreshPath(target.fsPath);
         }
       }),
-      vscode.commands.registerCommand("mermaidChart.appReviewBackToPending", async (uri?: vscode.Uri) => {
-        const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      vscode.commands.registerCommand("mermaidChart.appReviewBackToPending", async (arg) => {
+        const target = this.resolveReviewTarget(arg);
         if (target) {
           await this.diffViewProvider.restoreAppProposalAndPending(target);
           await this.gitStatusTracker.refreshPath(target.fsPath);
@@ -117,8 +306,8 @@ export class AppReviewFeature implements vscode.Disposable {
       vscode.commands.registerCommand("mermaidChart.commitAppReview", (uri: vscode.Uri) =>
         this.commitWorkflow.commitAppReview(uri)
       ),
-      vscode.commands.registerCommand("mermaidChart.closeAppReview", async (uri?: vscode.Uri) => {
-        const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      vscode.commands.registerCommand("mermaidChart.closeAppReview", async (arg) => {
+        const target = this.resolveReviewTarget(arg);
         if (!target) {
           return;
         }
@@ -128,12 +317,17 @@ export class AppReviewFeature implements vscode.Disposable {
         this.gitStatusTracker.invalidatePath(absolutePath);
         this.fileDecorationProvider.refresh();
         this.codeLensProvider.refresh();
+        this.reviewSyncTree.refresh();
+        this.refreshReviewScmIfOpen();
         if (removed) {
           vscode.window.showInformationMessage("Review closed for this file.");
         } else {
           vscode.window.showWarningMessage("No active app review for this file.");
         }
-      })
+      }),
+      vscode.commands.registerCommand("mermaidChart.focusReviewMermaidSync", async () => {
+        await this.reviewSyncTree.focusView();
+      }),
     );
   }
 
@@ -169,6 +363,8 @@ export class AppReviewFeature implements vscode.Disposable {
       this.integration.onDidChangePendingReviews(() => {
         this.fileDecorationProvider.refresh();
         this.codeLensProvider.refresh();
+        this.reviewSyncTree.refresh();
+        this.refreshReviewScmIfOpen();
         void this.gitStatusTracker.refreshAllMapped();
       })
     );
@@ -181,5 +377,7 @@ export class AppReviewFeature implements vscode.Disposable {
     this.fileDecorationProvider.dispose();
     this.diffViewProvider.dispose();
     this.codeLensProvider.dispose();
+    this.reviewSyncTree.dispose();
+    this.reviewScmSync.dispose();
   }
 }

--- a/src/appReviewGitPullWatcher.ts
+++ b/src/appReviewGitPullWatcher.ts
@@ -21,7 +21,10 @@ export class AppReviewGitPullWatcher implements vscode.Disposable {
   private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly fsWatchers: FSWatcher[] = [];
 
-  constructor(private readonly integration: AppReviewIntegration) {}
+  constructor(
+    private readonly integration: AppReviewIntegration,
+    private readonly onFilesRegistered?: (count: number) => void | Promise<void>,
+  ) {}
 
   start(context: vscode.ExtensionContext): void {
     void this.setupFileWatchersForWorkspace();
@@ -90,7 +93,10 @@ export class AppReviewGitPullWatcher implements vscode.Disposable {
       return;
     }
     this.lastHeadByRepo.set(repoKey, headSha);
-    await this.integration.reviewAppCommits({ trigger: "git-update", fromSHA: previous });
+    const count = await this.integration.reviewAppCommits({ trigger: "git-update", fromSHA: previous });
+    if (count > 0) {
+      await this.onFilesRegistered?.(count);
+    }
   }
 
   private async readHeadSha(cwd: string): Promise<string | null> {

--- a/src/appReviewIntegration.ts
+++ b/src/appReviewIntegration.ts
@@ -70,7 +70,8 @@ export class AppReviewIntegration {
     this._onDidChangePendingReviews.fire();
   }
 
-  async reviewAppCommits(options: ReviewAppCommitsOptions = {}): Promise<void> {
+  /** Number of diagram files registered for review (0 if none or on failure). */
+  async reviewAppCommits(options: ReviewAppCommitsOptions = {}): Promise<number> {
     const trigger = options.trigger ?? "manual";
     const silent = trigger === "git-update";
 
@@ -80,12 +81,12 @@ export class AppReviewIntegration {
         if (!silent) {
           vscode.window.showErrorMessage("Open a folder workspace to review app sync commits.");
         }
-        return;
+        return 0;
       }
 
       const authed = await this.ensureGitHubAuthentication(silent);
       if (!authed) {
-        return;
+        return 0;
       }
 
       this.githubContext = null;
@@ -96,7 +97,7 @@ export class AppReviewIntegration {
             "No open GitHub pull request found for this branch. App review needs PR base content from GitHub."
           );
         }
-        return;
+        return 0;
       }
 
       const gitRoot =
@@ -110,7 +111,7 @@ export class AppReviewIntegration {
         if (!silent) {
           vscode.window.showErrorMessage("Could not read HEAD. Is this a git repository?");
         }
-        return;
+        return 0;
       }
 
       // Manual: entire PR (PR base → HEAD). Pull: only this pull (pre-pull HEAD → HEAD).
@@ -124,7 +125,7 @@ export class AppReviewIntegration {
             "No .mmd/.mermaid files touched by Mermaid Sync app commits in the selected range."
           );
         }
-        return;
+        return 0;
       }
 
       await this.registerPendingAppReviews(
@@ -138,19 +139,21 @@ export class AppReviewIntegration {
       );
       analytics.trackAppReviewTriggered();
 
-      const message = `Mermaid Sync app updated ${relPaths.length} diagram file(s). Open each file to Review / Accept / Reject from CodeLens.`;
+      const message = `Mermaid Sync app updated ${relPaths.length} diagram file(s). See Review Mermaid Sync in the sidebar.`;
       if (silent) {
         vscode.window.showInformationMessage(message);
       } else {
         vscode.window.showInformationMessage(
-          `Marked ${relPaths.length} diagram file(s) for Mermaid Sync app review. Open each file for Review / Accept / Reject / Submit.`,
+          `Marked ${relPaths.length} diagram file(s) for Mermaid Sync app review.`,
         );
       }
+      return this.reviewMappings.size;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       if (!silent) {
         vscode.window.showErrorMessage(`App review failed: ${msg}`);
       }
+      return 0;
     }
   }
 
@@ -337,6 +340,18 @@ export class AppReviewIntegration {
       return true;
     }
     return false;
+  }
+
+  /** End the review session and clear every mapped diagram (does not revert file content). */
+  clearAllReviews(): number {
+    const count = this.reviewMappings.size;
+    if (count === 0) {
+      return 0;
+    }
+    this.reviewMappings.clear();
+    this.activeGitRoot = null;
+    this.notifyReviewMappingsChanged();
+    return count;
   }
 
   private isSyncAppBotCommit(info: {

--- a/src/appReviewScmSync.ts
+++ b/src/appReviewScmSync.ts
@@ -1,0 +1,115 @@
+import * as vscode from "vscode";
+import type { AppReviewIntegration, ReviewFileMapping } from "./appReviewIntegration";
+import { resolveReviewDiagramUri, reviewStatusDecoration } from "./appReviewStatus";
+
+/** SCM id — must match `when`: scmProvider == mermaidSyncReview in package.json */
+export const MERMAID_SYNC_REVIEW_SCM_ID = "mermaidSyncReview";
+
+/**
+ * Lightweight hidden SCM bridge used only while the Open Changes multi-diff tab is open.
+ * VS Code needs an SCM provider for per-row Accept / Reject in that editor.
+ * `isHidden` (scmProviderOptions) keeps it out of the Source Control sidebar UI.
+ */
+export class AppReviewScmSync implements vscode.Disposable {
+  private scm?: vscode.SourceControl;
+  private resourceGroup?: vscode.SourceControlResourceGroup;
+
+  constructor(private readonly integration: AppReviewIntegration) {}
+
+  /** Register SCM + sync files; call right before opening Open Changes. */
+  ensureForMultiDiff(): vscode.Uri | undefined {
+    const mappings = [...this.integration.getReviewMappings().values()].sort((a, b) =>
+      a.relativePath.localeCompare(b.relativePath),
+    );
+    if (mappings.length === 0) {
+      this.releaseMultiDiff();
+      return undefined;
+    }
+
+    const root = vscode.workspace.workspaceFolders?.[0]?.uri;
+    if (!this.scm) {
+      this.scm = vscode.scm.createSourceControl(
+        MERMAID_SYNC_REVIEW_SCM_ID,
+        "Mermaid Sync Review",
+        root,
+        undefined,
+        true,
+      );
+      this.scm.inputBox.visible = false;
+      this.resourceGroup = this.scm.createResourceGroup("changes", "Changes");
+      this.resourceGroup.hideWhenEmpty = true;
+    }
+
+    this.applyResourceStates(mappings);
+    return vscode.Uri.from({ scheme: "scm-multi-diff", path: MERMAID_SYNC_REVIEW_SCM_ID });
+  }
+
+  /** Keep Open Changes row actions in sync when a file is accepted/rejected while the tab is open. */
+  refreshIfActive(): void {
+    if (!this.scm) {
+      return;
+    }
+    const mappings = [...this.integration.getReviewMappings().values()].sort((a, b) =>
+      a.relativePath.localeCompare(b.relativePath),
+    );
+    if (mappings.length === 0) {
+      this.releaseMultiDiff();
+      return;
+    }
+    this.applyResourceStates(mappings);
+  }
+
+  /** Tear down SCM when Open Changes closes — removes the extra list from Source Control. */
+  releaseMultiDiff(): void {
+    this.disposeScm();
+  }
+
+  private applyResourceStates(mappings: ReviewFileMapping[]): void {
+    this.resourceGroup!.resourceStates = mappings.map((mapping) => {
+      const status = reviewStatusDecoration(mapping.status);
+      return {
+        resourceUri: vscode.Uri.file(mapping.originalFilePath),
+        contextValue: "mermaidReviewSyncFile",
+        decorations: {
+          strikeThrough: false,
+          tooltip: `${mapping.relativePath} (${status.label})`,
+          icon: undefined,
+          letter: status.badge,
+          color: status.color,
+        },
+      };
+    });
+    this.scm!.count = mappings.length;
+  }
+
+  private disposeScm(): void {
+    this.scm?.dispose();
+    this.scm = undefined;
+    this.resourceGroup = undefined;
+  }
+
+  dispose(): void {
+    this.disposeScm();
+  }
+}
+
+export function resolveReviewCommandTarget(
+  arg?: vscode.Uri | vscode.TreeItem | vscode.SourceControlResourceState,
+): vscode.Uri | undefined {
+  if (!arg) {
+    return undefined;
+  }
+
+  if (arg instanceof vscode.Uri) {
+    return resolveReviewDiagramUri(arg);
+  }
+
+  const resourceUri =
+    arg instanceof vscode.TreeItem
+      ? arg.resourceUri
+      : "resourceUri" in arg && arg.resourceUri instanceof vscode.Uri
+        ? arg.resourceUri
+        : undefined;
+
+  return resourceUri ? resolveReviewDiagramUri(resourceUri) : undefined;
+}

--- a/src/appReviewStatus.ts
+++ b/src/appReviewStatus.ts
@@ -1,0 +1,60 @@
+import * as vscode from "vscode";
+import type { ReviewFileMapping } from "./appReviewIntegration";
+
+/** Tree-only URI scheme so Git SCM decorations (M) do not stack on review status badges. */
+export const MERMAID_REVIEW_URI_SCHEME = "mermaid-review";
+
+export function toReviewTreeUri(absoluteFilePath: string): vscode.Uri {
+  return vscode.Uri.file(absoluteFilePath).with({ scheme: MERMAID_REVIEW_URI_SCHEME });
+}
+
+export function fsPathFromReviewUri(uri: vscode.Uri): string | null {
+  if (uri.scheme !== MERMAID_REVIEW_URI_SCHEME) {
+    return null;
+  }
+  return uri.fsPath;
+}
+
+/** Tree/context URIs use `mermaid-review:`; review commands need the workspace file URI. */
+export function resolveReviewDiagramUri(uri?: vscode.Uri): vscode.Uri | undefined {
+  if (!uri) {
+    return undefined;
+  }
+  const fsPath = uri.scheme === MERMAID_REVIEW_URI_SCHEME ? fsPathFromReviewUri(uri) : uri.fsPath;
+  return fsPath ? vscode.Uri.file(fsPath) : undefined;
+}
+
+/** Git-style letter + theme color for a review file status. */
+export function reviewStatusDecoration(status: ReviewFileMapping["status"]): {
+  badge: string;
+  color: vscode.ThemeColor;
+  label: string;
+} {
+  switch (status) {
+    case "accepted":
+      return {
+        badge: "A",
+        color: new vscode.ThemeColor("gitDecoration.addedResourceForeground"),
+        label: "Accepted",
+      };
+    case "rejected":
+      return {
+        badge: "R",
+        color: new vscode.ThemeColor("gitDecoration.deletedResourceForeground"),
+        label: "Rejected",
+      };
+    case "modified":
+      return {
+        badge: "M",
+        color: new vscode.ThemeColor("gitDecoration.modifiedResourceForeground"),
+        label: "Modified",
+      };
+    case "pending":
+    default:
+      return {
+        badge: "M",
+        color: new vscode.ThemeColor("gitDecoration.modifiedResourceForeground"),
+        label: "Modified",
+      };
+  }
+}

--- a/src/panels/previewPanel.ts
+++ b/src/panels/previewPanel.ts
@@ -112,7 +112,7 @@ export class PreviewPanel {
     
     console.log('Theme colors:', vscodeThemeColors);
 
-      this.lastContent = this.document.getText() || " ";
+      this.lastContent = (this.document.getText() || " ").replace(/\r\n/g, '\n');
   
     if (!this.panel.webview.html) {
       this.panel.webview.html = getWebviewHTML(this.panel, extensionPath, this.lastContent, currentTheme, false, {

--- a/src/reviewMermaidSyncTreeProvider.ts
+++ b/src/reviewMermaidSyncTreeProvider.ts
@@ -1,0 +1,89 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import type { AppReviewIntegration } from "./appReviewIntegration";
+import { toReviewTreeUri } from "./appReviewStatus";
+
+export class ReviewMermaidSyncTreeProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem>, vscode.Disposable
+{
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private treeView?: vscode.TreeView<vscode.TreeItem>;
+
+  constructor(private readonly integration: AppReviewIntegration) {}
+
+  register(context: vscode.ExtensionContext): vscode.TreeView<vscode.TreeItem> {
+    this.treeView = vscode.window.createTreeView("mermaidReviewSync", {
+      treeDataProvider: this,
+      showCollapseAll: false,
+    });
+    context.subscriptions.push(this.treeView, this);
+    return this.treeView;
+  }
+
+  refresh(): void {
+    this.updateVisibilityContext();
+    this.updateTitle();
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  async focusView(): Promise<void> {
+    this.refresh();
+    await vscode.commands.executeCommand("workbench.view.extension.mermaidActivityBar");
+    await vscode.commands.executeCommand("mermaidReviewSync.focus");
+  }
+
+  private updateVisibilityContext(): void {
+    const hasItems = this.integration.getReviewMappings().size > 0;
+    void vscode.commands.executeCommand("setContext", "mermaid.hasAppReviewSync", hasItems);
+  }
+
+  private updateTitle(): void {
+    if (!this.treeView) {
+      return;
+    }
+    const mappings = [...this.integration.getReviewMappings().values()];
+    const pending = mappings.filter((m) => m.status === "pending").length;
+    if (mappings.length === 0) {
+      this.treeView.title = "Review Mermaid Sync";
+      return;
+    }
+    this.treeView.title =
+      pending > 0
+        ? `Review Mermaid Sync (${mappings.length} · ${pending} pending)`
+        : `Review Mermaid Sync (${mappings.length})`;
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    const mappings = [...this.integration.getReviewMappings().values()].sort((a, b) =>
+      a.relativePath.localeCompare(b.relativePath),
+    );
+
+    return mappings.map((mapping) => {
+      const fileUri = vscode.Uri.file(mapping.originalFilePath);
+      const item = new vscode.TreeItem(
+        path.basename(mapping.originalFilePath),
+        vscode.TreeItemCollapsibleState.None,
+      );
+      // Custom scheme: our R/A/M badges only — Git must not add M for working-tree changes.
+      item.resourceUri = toReviewTreeUri(mapping.originalFilePath);
+      item.tooltip = mapping.relativePath;
+      item.command = {
+        command: "vscode.open",
+        title: "Open Diagram",
+        arguments: [fileUri, { preview: false, viewColumn: vscode.ViewColumn.Active }],
+      };
+      item.contextValue = "mermaidReviewSyncFile";
+      return item;
+    });
+  }
+
+  dispose(): void {
+    this._onDidChangeTreeData.dispose();
+  }
+}

--- a/src/vscode.proposed.scmProviderOptions.d.ts
+++ b/src/vscode.proposed.scmProviderOptions.d.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ * Proposed API: scmProviderOptions — https://github.com/microsoft/vscode/issues/254910
+ * Enables createSourceControl(..., isHidden) to keep provider out of Source Control UI.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module "vscode" {
+  export interface SourceControl {
+    /**
+     * Context value for scm/sourceControl/context menu when clauses.
+     */
+    contextValue?: string;
+
+    /**
+     * Fired when the parent source control is disposed.
+     */
+    readonly onDidDisposeParent: Event<void>;
+  }
+
+  export namespace scm {
+    export function createSourceControl(
+      id: string,
+      label: string,
+      rootUri?: Uri,
+      iconPath?: IconPath,
+      isHidden?: boolean,
+      parent?: SourceControl,
+    ): SourceControl;
+  }
+}

--- a/webview/src/App.svelte
+++ b/webview/src/App.svelte
@@ -134,7 +134,8 @@
   async function validateDiagramOnly(content: string) {
     try {
       await initializeMermaid();
-      await mermaid.parse(content || 'info');
+      const normalizedContent = (content || '').replace(/\r\n/g, '\n');
+      await mermaid.parse(normalizedContent || 'info');
       vscode.postMessage({
         type: "validationResult",
         valid: true
@@ -717,7 +718,7 @@
         await validateDiagramOnly(content);
       } else if (content) {
         // Regular rendering flow
-        diagramContent = content;
+        diagramContent = content.replace(/\r\n/g, '\n');
         if (currentTheme) {
           const nextTheme = String(currentTheme).includes("%")
             ? decodeURIComponent(String(currentTheme))


### PR DESCRIPTION
This pull request introduces  Review Mermaid Sync (Slice 3): a Git-style sidebar for bot-updated diagrams on a PR, with bulk and per-file review actions and a unified Open Changes diff view.

- Native TreeView (mermaidReviewSync) listing all in-review .mmd files with M/A/R badges
- Toolbar: Open Changes, Accept all, Reject all, Close review (bulk accept/reject require Mermaid Chart login)
- Per-file +, discard, and close on sidebar rows
- Open Changes multi-diff reuses existing diff logic (PR base temp file vs workspace file)
- Hidden temporary SCM bridge for Open Changes row actions (scmProviderOptions / isHidden)
- Custom mermaid-review:// URIs to avoid Git M badge stacking on tree rows
- Auto-focus sidebar after Review Mermaid Sync command or post–git-pull detection
