### PR TITLE
PLUG-92 Added AI SKills Pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 webview/.npmrc
 dist-preview
 dist-sidebar
+.github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 2.7.3 - 2026-07-23
+- Added **Mermaid AI Skills for GitHub Copilot** — install workspace instructions so Copilot can use Mermaid extension commands and LM tools (preview, repair, improve, generate, sync, and more).
+
 ### 2.7.2 - 2026-07-2
 - Resolved an issue where zoom reset after changing text.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-### 2.7.3 - 2026-07-23
+### 2.7.4 - 2026-07-23
 - Added **Mermaid AI Skills for GitHub Copilot** — install workspace instructions so Copilot can use Mermaid extension commands and LM tools (preview, repair, improve, generate, sync, and more).
 
 ### 2.7.2 - 2026-07-2

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Transform ideas into diagrams instantly with our AI integration! Our extension n
 - **AI-Powered Sequence Diagrams**: Generate execution sequence diagrams from your modular code, showing interactions between components, classes, and methods
 - **AI-Powered C4 Architecture Diagrams**: Generate top-down C4 architecture diagrams from your codebase, visualizing system components and their relationships
 - **AI-Powered Generate Diagram from Code**: Generate flowcharts, class diagrams, sequence diagrams, and more directly from your source code files
+- **Mermaid AI Skills for GitHub Copilot**: Install workspace instructions so Copilot can call Mermaid extension commands (preview, repair, generate, sync, and more) when you need them
 
 > **Note**<br/>
 > To use the AI diagramming feature, you must have the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension installed.
@@ -513,6 +514,30 @@ To get the latest changes of diagrams from Mermaid Chart, click on the button na
 Users now have the option to open and edit diagrams in the web view on https://mermaid.ai in the browser. This will enable them to use the best-in-class Visual Editor with drag and drop interface to modify the diagram, Mermaid AI, use diagrams in Presentations etc
 ![Open in Web View](https://mermaid.ai/docs/img/plugins/vscode-plugin-mermaidchart.png)
 
+### Mermaid AI Skills for GitHub Copilot
+
+Teach [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) how to use this extension’s tools and commands automatically — so when you ask for a diagram in Copilot Chat, Copilot can decide which Mermaid Chart command to run (preview, repair, generate, connect to Mermaid Chart, and more) instead of you hunting the Command Palette.
+
+**How to install**
+
+1. Make sure [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) is installed in VS Code.
+2. Run **MermaidChart: Install AI Skills for GitHub Copilot** from the Command Palette, or choose **Add Mermaid Skills** when the extension prompts you.
+3. The extension writes Copilot instruction files into your workspace under `.github/` (full guide + a short pointer in `copilot-instructions.md`).
+
+**What Copilot can do after install**
+
+Once the skills are in your repo, Copilot can use Mermaid extension capabilities when your prompt needs them, for example:
+
+- **Preview** a diagram after writing a `.mmd` file
+- **Repair** broken Mermaid syntax with Mermaid AI
+- **Improve** layout and styling of the current diagram
+- **Generate** diagrams from code (cloud, ER, Docker, from-code, and `@mermaid-chart` slash commands)
+- **Login / connect / sync** diagrams with Mermaid Chart when cloud linking is needed
+- **Review Mermaid Sync** / **Regenerate** when diagrams stay in sync with code changes
+
+> **Note**<br/>
+> Mermaid AI Skills are for **GitHub Copilot in VS Code** only. They rely on VS Code commands and Copilot LM tools, which other AI IDEs cannot invoke the same way.
+
 ### Commands
 
 | Command | Description |
@@ -530,6 +555,7 @@ Users now have the option to open and edit diagrams in the web view on https://m
 | **MermaidChart: Commit App Review** | Commits reviewed diagram changes for the active file; optionally adds paths to `.mermaidignore`. |
 | **MermaidChart: Accept App Review** / **Reject App Review** | Accept or reject the app proposal for the file under review (also available via CodeLens). |
 | **MermaidChart: Generate Diagram from Code** | Opens GitHub Copilot Chat and runs `@mermaid-chart /generate_diagram_from_code` to generate a Mermaid diagram from the active code file. |
+| **MermaidChart: Install AI Skills for GitHub Copilot** | Adds Mermaid AI Skills to the workspace so GitHub Copilot can use extension commands and LM tools for diagram workflows. |
 
 
 ### Extension Settings
@@ -537,6 +563,8 @@ Users now have the option to open and edit diagrams in the web view on https://m
 This extension contributes the following settings:
 - `mermaidChart.baseUrl`: This points to the instance of the mermaid chart you are running, for the public service this is `https://mermaid.ai/`.
 - `mermaidChart.showGenerateDiagramCodeLens`: Show "Generate Mermaid Diagram" and "Open Chat @mermaid-chart" CodeLens at the bottom of supported code files (default: `true`). Set to `false` to hide CodeLens
+- `mermaidChart.aiSkills.enabled`: Enable the Mermaid AI Skills Pack for GitHub Copilot (default: `true`)
+- `mermaidChart.aiSkills.promptOnDetect`: Prompt to install Mermaid AI Skills for GitHub Copilot (monthly until you add the skills)
 - `mermaid.vscode.dark`: Defines the theme used for Mermaid diagrams when VS Code is in dark mode.
 - `mermaid.vscode.light`: Defines the theme used for Mermaid diagrams when VS Code is in light mode.
 - `mermaid.vscode.maxZoom`: Sets the maximum zoom level for diagram preview (default: 10).

--- a/README.md
+++ b/README.md
@@ -574,6 +574,9 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 2.7.3 - 2026-07-23
+- Added **Mermaid AI Skills for GitHub Copilot** — install workspace instructions so Copilot can use Mermaid extension commands and LM tools (preview, repair, improve, generate, sync, and more).
+
 ### 2.7.2 - 2026-07-2
 - Resolved an issue where zoom reset after changing text.
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ This extension contributes the following settings:
 
 ## Release Notes
 
-### 2.7.3 - 2026-07-23
+### 2.7.4 - 2026-07-23
 - Added **Mermaid AI Skills for GitHub Copilot** — install workspace instructions so Copilot can use Mermaid extension commands and LM tools (preview, repair, improve, generate, sync, and more).
 
 ### 2.7.2 - 2026-07-2

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "MermaidChart",
   "displayName": "Mermaid",
   "description": "The official Mermaid Editor plugin by the Mermaid open source team, now with AI-powered diagramming! Create, edit and preview diagrams seamlessly within VS Code",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "icon": "images/mermaid-chart.png",
   "repository": "github:Mermaid-Chart/vscode-mermaid-chart",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -673,6 +673,16 @@
           "type": "boolean",
           "default": true,
           "description": "Show 'Generate Mermaid Diagram' and 'Open Chat @mermaid-chart' CodeLens at the bottom of supported code files"
+        },
+        "mermaidChart.aiSkills.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the Mermaid AI Skills Pack for GitHub Copilot (writes instruction files under .github)"
+        },
+        "mermaidChart.aiSkills.promptOnDetect": {
+          "type": "boolean",
+          "default": true,
+          "description": "Prompt to install Mermaid AI Skills for GitHub Copilot (monthly until the user adds the skills)"
         }
       }
     },
@@ -951,6 +961,10 @@
       {
         "command": "mermaidChart.openCopilotChat",
         "title": "MermaidChart: Open AI Chat"
+      },
+      {
+        "command": "mermaidChart.installAiSkills",
+        "title": "MermaidChart: Install AI Skills for GitHub Copilot"
       },
       {
         "command": "mermaidChart.generateCloudDiagram",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "MermaidChart",
   "displayName": "Mermaid",
   "description": "The official Mermaid Editor plugin by the Mermaid open source team, now with AI-powered diagramming! Create, edit and preview diagrams seamlessly within VS Code",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "icon": "images/mermaid-chart.png",
   "repository": "github:Mermaid-Chart/vscode-mermaid-chart",
   "engines": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -175,6 +175,14 @@ class Analytics {
       "VS_CODE_PLUGIN_CONNECT_DIAGRAM",
     );
   }
+
+  // AI Skills Pack — fired once when Copilot skill files are written to the repo
+  public trackAiSkillsInstalled() {
+    this.sendEvent(
+      "VS Code AI Skills Pack Installed",
+      "VS_CODE_PLUGIN_AI_SKILLS_INSTALLED",
+    );
+  }
 }
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,7 @@ import { extendMarkdownItWithMermaid } from "./previewmarkdown/shared-md-mermaid
 import * as packageJson from '../package.json'; 
 import { clearTmLanguageCache } from "./syntaxHighlighter";
 import { AppReviewFeature } from "./appReviewFeature";
+import { getWorkspaceRoot, installSkillPack, isInstalled } from "./services/aiSkillsInstaller";
 
 
 const pluginID = packageJson.name === "vscode-mermaid-chart" ?  "MERMAIDCHART_VS_CODE_PLUGIN" : "MERMAID_PREVIEW_VS_CODE_PLUGIN";
@@ -1042,6 +1043,90 @@ context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
 registerRegenerateCommand(context, mcAPI);
 registerRegenerateWithMermaidAICommand(context, mcAPI);
 PreCommitSyncService.register(context, mcAPI);
+
+// ── AI Skills Pack (GitHub Copilot only) ────────────────────────────────────
+
+/** Set to false before release — when true, toast shows on every activate (no globalState). */
+const aiSkillsToastAlwaysShowForTesting = true;
+
+const aiSkillsToastLastShownKey = "mermaidAiSkills.toastLastShownAt";
+const oneMonthMs = 30 * 24 * 60 * 60 * 1000;
+
+async function showAiSkillsToast(): Promise<void> {
+  const config = vscode.workspace.getConfiguration("mermaidChart");
+  if (!config.get<boolean>("aiSkills.enabled", true)) { return; }
+  if (!config.get<boolean>("aiSkills.promptOnDetect", true)) { return; }
+
+  const root = getWorkspaceRoot();
+  // Stop prompting once skills are actually installed in the workspace
+  if (root && isInstalled(root)) { return; }
+
+  if (!aiSkillsToastAlwaysShowForTesting) {
+    // Re-prompt at most once per month until the user adds skills
+    const lastShownAt = context.globalState.get<number>(aiSkillsToastLastShownKey, 0);
+    if (lastShownAt > 0 && Date.now() - lastShownAt < oneMonthMs) { return; }
+  }
+
+  const choice = await vscode.window.showInformationMessage(
+    "Mermaid Extension has an AI Skills Pack for GitHub Copilot — teach Copilot to use Mermaid tools and commands to generate and preview diagrams correctly.",
+    "Add Mermaid Skills",
+    "Ignore"
+  );
+
+  if (!aiSkillsToastAlwaysShowForTesting) {
+    // Ignore / dismiss only delays the next prompt by one month — does not stop forever
+    context.globalState.update(aiSkillsToastLastShownKey, Date.now());
+  }
+
+  if (choice === "Add Mermaid Skills") {
+    vscode.commands.executeCommand("mermaidChart.installAiSkills");
+  }
+}
+
+// Palette command: MermaidChart: Install AI Skills… (Copilot / .github only)
+context.subscriptions.push(
+  vscode.commands.registerCommand("mermaidChart.installAiSkills", async () => {
+    const config = vscode.workspace.getConfiguration("mermaidChart");
+    if (!config.get<boolean>("aiSkills.enabled", true)) {
+      vscode.window.showWarningMessage("Mermaid AI Skills is disabled. Enable mermaidChart.aiSkills.enabled to use this feature.");
+      return;
+    }
+
+    const copilotChat = vscode.extensions.getExtension("GitHub.copilot-chat");
+    if (!copilotChat) {
+      const installOption = "Install GitHub Copilot Chat";
+      const selection = await vscode.window.showErrorMessage(
+        "Mermaid AI Skills only works with GitHub Copilot in VS Code — not with Cursor, Windsurf, or other AI assistants. Install GitHub Copilot Chat to continue.",
+        installOption
+      );
+      if (selection === installOption) {
+        await vscode.commands.executeCommand("extension.open", "GitHub.copilot-chat");
+      }
+      return;
+    }
+
+    const root = getWorkspaceRoot();
+    if (!root) {
+      vscode.window.showWarningMessage("No workspace folder open.");
+      return;
+    }
+
+    const result = installSkillPack(root);
+    analytics.trackAiSkillsInstalled();
+
+    const fileLines = result.filesWritten
+      .map((f) => `${f.created ? "Created" : "Updated"}: ${f.path.slice(root.length + 1)}`)
+      .join("\n");
+    vscode.window.showInformationMessage(
+      `Mermaid AI Skills installed for GitHub Copilot.\n${fileLines}`
+    );
+  })
+);
+
+// Toast — runs off the hot path 3 s after activation
+setTimeout(() => { showAiSkillsToast().catch(console.error); }, 3000);
+
+// ── End AI Skills Pack ──────────────────────────────────────────────────────
 
 context.subscriptions.push(
   vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1065,7 +1065,7 @@ PreCommitSyncService.register(context, mcAPI);
 // ── AI Skills Pack (GitHub Copilot only) ────────────────────────────────────
 
 /** Set to false before release — when true, toast shows on every activate (no globalState). */
-const aiSkillsToastAlwaysShowForTesting = true;
+const aiSkillsToastAlwaysShowForTesting = false;
 
 const aiSkillsToastLastShownKey = "mermaidAiSkills.toastLastShownAt";
 const oneMonthMs = 30 * 24 * 60 * 60 * 1000;

--- a/src/services/aiSkillsContent.ts
+++ b/src/services/aiSkillsContent.ts
@@ -1,0 +1,105 @@
+export const blockStart = "<!-- mermaid-ai-skills:start -->";
+export const blockEnd = "<!-- mermaid-ai-skills:end -->";
+
+/**
+ * Copilot-only Mermaid AI Skills content.
+ * VS Code commands / LM tools only work with GitHub Copilot in the VS Code host.
+ */
+export function getCopilotSkillContent(): string {
+  return `---
+applyTo: "**"
+---
+# Mermaid AI Skills
+
+When the user asks to create, edit, or visualize any diagram, use the Mermaid
+VS Code extension tools and commands described below.
+
+## Workflow
+
+1. Determine the diagram type and generate Mermaid syntax.
+2. Write the diagram to a \`.mmd\` file in the project.
+3. Validate syntax: correct first-line keyword, arrow types, balanced brackets.
+4. Preview via the Mermaid extension — open the \`.mmd\` file (auto-preview) or run
+   **MermaidChart: Preview Diagram** (\`mermaidChart.preview\`).
+
+## LM Tools — call these for every diagram interaction
+
+- \`mermaid-diagram-validator\` — validate Mermaid syntax before presenting any diagram
+- \`mermaid-diagram-preview\` — render a live preview inside VS Code after generating
+- \`get-syntax-docs-mermaid\` — fetch correct syntax docs for any diagram type
+
+## VS Code Commands
+
+Invoke via Command Palette or the VS Code command API (GitHub Copilot in VS Code only).
+Do not invent command IDs. Prefer writing/editing \`.mmd\` files when a command is not needed.
+
+### Diagram editing & preview
+- **Preview** (\`mermaidChart.preview\`) — preview the active Mermaid editor (\`.mmd\` / \`.mermaid\` must be open).
+- **Create Diagram** (\`mermaidChart.createMermaidFile\`) — creates a demo flowchart and opens preview side by side.
+- **Repair Diagram** (\`mermaidChart.repairDiagram\`) — Mermaid AI repair for the active diagram; uses Mermaid AI credits — tell the user before running.
+- **Improve Diagram** (\`mermaidChart.improveDiagram\`) — uses Copilot / LM API; suggests layout + styling variants for the active diagram.
+
+### Generate diagrams (GitHub Copilot required)
+- **Generate Diagram from Code** (\`mermaidChart.generateDiagramFromCode\`)
+- **Generate Cloud Diagram** (\`mermaidChart.generateCloudDiagram\`)
+- **Generate ER Diagram** (\`mermaidChart.generateERDiagram\`)
+- **Generate Docker Diagram** (\`mermaidChart.generateDockerDiagram\`)
+- **Open AI Chat** (\`mermaidChart.openCopilotChat\`)
+
+### Mermaid Chart cloud
+- **Login** (\`mermaidChart.login\`) / **Logout** (\`mermaidChart.logout\`)
+- **Connect Diagram** (\`mermaidChart.connectDiagramToMermaidChart\`) — link a local diagram to Mermaid Chart.
+- **Sync Diagram** (\`mermaidChart.syncDiagramWithMermaid\`) — only for diagrams already connected (frontmatter has \`id:\`). Example:
+  \`\`\`yaml
+  ---
+  id: cbd9e9ba-a2cb-47c5-a98e-8c28a753428d
+  ---
+  \`\`\`
+
+### Review Mermaid Sync
+For diagrams updated by the Mermaid Chart GitHub Sync app (or pre-commit regenerate):
+- **Review Mermaid Sync** (\`mermaidChart.reviewAppCommits\`) — start / open the review flow.
+- **Regenerate with Mermaid AI** (\`mermaidChart.regenerateDiagramWithMermaidAI\`) — regenerate from source references.
+Do not manually rewrite diagrams managed by this workflow. Accept/reject/diff UI actions stay in the extension UI.
+
+### Install / update this pack
+- **MermaidChart: Install AI Skills…** (\`mermaidChart.installAiSkills\`)
+
+## @mermaid-chart slash commands
+
+| Command | Purpose |
+|---|---|
+| \`/generate_diagram_from_code\` | General diagram from any source file |
+| \`/generate_execution_sequence\` | Sequence diagram from code flow |
+| \`/generate_er_diagram\` | ER diagram from schema / models |
+| \`/generate_cloud_architecture_diagram\` | Cloud / CI-CD architecture |
+| \`/generate_docker_diagram\` | Architecture from Dockerfiles |
+| \`/generate_c4_topdown_architecture\` | C4 top-down architecture |
+| \`/analyze_code_ownership\` | Code ownership diagram |
+| \`/generate_dependency_diagram\` | Dependency / security visualisation |
+
+## Rules
+
+1. Always call \`mermaid-diagram-validator\` before showing any diagram.
+2. Always call \`mermaid-diagram-preview\` after generating a diagram.
+3. Use \`get-syntax-docs-mermaid\` before generating an unfamiliar diagram type.
+4. Prefer \`@mermaid-chart\` slash commands for complex generation.
+5. Write diagrams to \`.mmd\` files; never return unvalidated Mermaid syntax.
+6. Warn the user before Repair (Mermaid AI credits).
+7. Cooperate with the Sync workflow — do not manually regenerate managed diagrams.
+
+## Docs
+
+More commands and features: https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart
+`;
+}
+
+/** Short pointer for .github/copilot-instructions.md */
+export function getCopilotPointer(): string {
+  return `${blockStart}
+## Mermaid Diagrams
+
+When the user asks to create, edit, or visualize a diagram, follow the
+instructions in \`.github/instructions/mermaid.instructions.md\`.
+${blockEnd}`;
+}

--- a/src/services/aiSkillsInstaller.ts
+++ b/src/services/aiSkillsInstaller.ts
@@ -1,0 +1,94 @@
+import * as path from "path";
+import * as fs from "fs";
+import * as vscode from "vscode";
+import {
+  blockStart,
+  blockEnd,
+  getCopilotSkillContent,
+  getCopilotPointer,
+} from "./aiSkillsContent";
+
+export interface InstallResult {
+  filesWritten: Array<{ path: string; created: boolean }>;
+}
+
+export function getWorkspaceRoot(): string | undefined {
+  const folders = vscode.workspace.workspaceFolders;
+  return folders && folders.length > 0 ? folders[0].uri.fsPath : undefined;
+}
+
+function ensureDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeMermaidSkills(
+  filePath: string,
+  content: string,
+  written: InstallResult["filesWritten"]
+): void {
+  const existed = fs.existsSync(filePath);
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, content, "utf8");
+  written.push({ path: filePath, created: !existed });
+}
+
+/** Adds or updates a Mermaid pointer block inside an always-on rules file. */
+function appendRulesWithMermaidSkills(
+  filePath: string,
+  block: string,
+  written: InstallResult["filesWritten"]
+): void {
+  const existed = fs.existsSync(filePath);
+  const existing = existed ? fs.readFileSync(filePath, "utf8") : "";
+  const startIdx = existing.indexOf(blockStart);
+  const endIdx = existing.indexOf(blockEnd);
+
+  let newContent: string;
+  if (startIdx !== -1 && endIdx !== -1) {
+    newContent =
+      existing.slice(0, startIdx) +
+      block +
+      existing.slice(endIdx + blockEnd.length);
+  } else {
+    const sep =
+      existing === "" || existing.endsWith("\n\n")
+        ? ""
+        : existing.endsWith("\n")
+          ? "\n"
+          : "\n\n";
+    newContent = existing + sep + block + "\n";
+  }
+
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, newContent, "utf8");
+  written.push({ path: filePath, created: !existed });
+}
+
+function getInstructionsPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".github", "instructions", "mermaid.instructions.md");
+}
+
+/** True when Copilot Mermaid instructions already exist on disk. */
+export function isInstalled(workspaceRoot: string): boolean {
+  return fs.existsSync(getInstructionsPath(workspaceRoot));
+}
+
+/**
+ * Installs Mermaid AI Skills for GitHub Copilot only
+ * (.github/instructions + pointer in copilot-instructions.md).
+ */
+export function installSkillPack(workspaceRoot: string): InstallResult {
+  const written: InstallResult["filesWritten"] = [];
+
+  writeMermaidSkills(getInstructionsPath(workspaceRoot), getCopilotSkillContent(), written);
+  appendRulesWithMermaidSkills(
+    path.join(workspaceRoot, ".github", "copilot-instructions.md"),
+    getCopilotPointer(),
+    written
+  );
+
+  return { filesWritten: written };
+}


### PR DESCRIPTION
## Summary
- Adds a **Mermaid AI Skills Pack for GitHub Copilot** that writes instruction files under `.github/` so Copilot can use extension commands (preview, repair, generate, sync, etc.) when diagram work comes up.
- Prompts users monthly until skills are installed (Ignore only delays; does not permanently dismiss).
- Documents the feature in the README and tracks a single install analytics event. which is this `VS_CODE_PLUGIN_AI_SKILLS_INSTALLED`

