### PR TITLE
PLUG-90 Added On-Commit Generate Diagram From Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 2.7.5 - 2026-08-5
+- Added **Generate Diagram for New Staged Files** — When you stage source files that aren't yet linked to any Mermaid diagram, the extension offers to generate a new diagram via Generate Diagram From Code. Can be disabled via Settings → **Mermaid Chart: Create Diagram From Stage Enabled**
+
 ### 2.7.4 - 2026-07-23
 - Added **Mermaid AI Skills for GitHub Copilot** — install workspace instructions so Copilot can use Mermaid extension commands and LM tools (preview, repair, improve, generate, sync, and more).
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,19 @@ Keep your Mermaid diagrams in sync with your code — automatically, before ever
 > **This is a focused, local version of Mermaid diagram sync.** It regenerates diagrams based on your current staged changes only.
 > For full pull-request-level diagram synchronization across your entire repository use the [**Mermaid Diagram Sync GitHub App**](https://github.com/marketplace/mermaid-diagram-sync).
 
-![vscode-plugin-precommit-regenerate](https://mermaid.ai/docs/img/plugins/vscode-plugin-precommit-regenerate.gif)
+### Generate Diagram for New Staged Files
+Visualize code you're about to commit — even before a diagram exists for it.
+
+When you stage source files that are not yet referenced by any `.mmd` or `.mermaid` diagram in your workspace, the extension detects them and offers to generate a brand-new diagram using Generate Diagram From Code — without blocking your commit.
+
+- **Automatic Detection**: Every time you run `git add`, the extension checks your staged coding files (TypeScript, Python, Java, Go,....) against all Mermaid diagrams in the workspace. If any staged file has no linked diagram, a soft notification appears.<br>
+- **One-Click Generation**: Click **Generate** in the notification and the extension automatically opens the Copilot chat with `@mermaid-chart /generate_diagram_from_code`, pre-seeding all the unlinked staged file paths as references — no manual file selection needed.<br>
+- **Choose Your Diagram Type**: Once the chat opens, you can pick the diagram type (flowchart, class diagram, sequence diagram, and more) and the AI generates the appropriate Mermaid syntax instantly.<br>
+- **Smart Frequency Limit**: The popup shows up to 2 times across interactions. After that, it enters a quiet period of approximately one month — whether you clicked Generate or dismissed it — so it never becomes intrusive.<br>
+- **Opt-out Anytime**: Can be turned off permanently via Settings → **Mermaid Chart: Create Diagram From Stage Enabled**.<br>
+- **Never Blocks Commit**: This is a soft, non-modal notification only. Your staging and commit flow is never interrupted regardless of your choice.<br>
+
+![vscode-plugin-create-diagram-from-stage](https://mermaid.ai/docs/img/plugins/vscode-plugin-create-diagram-from-stage.gif)
 
 
 ### Regenerate Diagram with Diff Preview
@@ -537,6 +549,8 @@ Once the skills are in your repo, Copilot can use Mermaid extension capabilities
 
 > **Note**<br/>
 > Mermaid AI Skills are for **GitHub Copilot in VS Code** only. They rely on VS Code commands and Copilot LM tools, which other AI IDEs cannot invoke the same way.
+
+![vscode-plugin-ai-skills](https://mermaid.ai/docs/img/plugins/vscode-plugin-ai-skills.gif)
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -588,6 +588,9 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 2.7.5 - 2026-08-5
+- Added **Generate Diagram for New Staged Files** — When you stage source files that aren't yet linked to any Mermaid diagram, the extension offers to generate a new diagram via Generate Diagram From Code. Can be disabled via Settings → **Mermaid Chart: Create Diagram From Stage Enabled**
+
 ### 2.7.4 - 2026-07-23
 - Added **Mermaid AI Skills for GitHub Copilot** — install workspace instructions so Copilot can use Mermaid extension commands and LM tools (preview, repair, improve, generate, sync, and more).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "MermaidChart",
   "displayName": "Mermaid",
   "description": "The official Mermaid Editor plugin by the Mermaid open source team, now with AI-powered diagramming! Create, edit and preview diagrams seamlessly within VS Code",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "icon": "images/mermaid-chart.png",
   "repository": "github:Mermaid-Chart/vscode-mermaid-chart",
   "engines": {
@@ -1287,7 +1287,7 @@
     "@iconify-json/logos": "^1.2.4",
     "@iconify-json/mdi": "^1.2.3",
     "@mermaid-chart/icons-gcp": "^1.0.0",
-    "@mermaid-chart/vscode-utils": "1.4.7",
+    "@mermaid-chart/vscode-utils": "1.4.8",
     "@mermaid-chart/layout-elk": "0.1.7-b.2",
     "@mermaidchart/sdk": "0.2.6",
     "@vscode/chat-extension-utils": "^0.0.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -1287,7 +1287,7 @@
     "@iconify-json/logos": "^1.2.4",
     "@iconify-json/mdi": "^1.2.3",
     "@mermaid-chart/icons-gcp": "^1.0.0",
-    "@mermaid-chart/vscode-utils": "1.4.6",
+    "@mermaid-chart/vscode-utils": "1.4.7",
     "@mermaid-chart/layout-elk": "0.1.7-b.2",
     "@mermaidchart/sdk": "0.2.6",
     "@vscode/chat-extension-utils": "^0.0.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -669,6 +669,11 @@
           "default": true,
           "description": "Enable pre-commit Mermaid diagram sync. When enabled, you will be notified to regenerate diagrams when staged source files match diagram references."
         },
+        "mermaidChart.createDiagramFromStage.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "When staging coding files that have no linked Mermaid diagram, offer to generate one with Generate Diagram From Code. Soft notification only — never blocks commit."
+        },
         "mermaidChart.showGenerateDiagramCodeLens": {
           "type": "boolean",
           "default": true,
@@ -990,7 +995,7 @@
         "command": "mermaidChart.regenerateDiagramWithMermaidAI",
         "title": "MermaidChart: Regenerate with Mermaid AI"
       },
-      {        
+      {
         "command": "mermaidChart.reviewAppCommits",
         "title": "MermaidChart: Review Mermaid Sync"
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 11.16.0-b.1
         version: 11.16.0-b.1
       '@mermaid-chart/vscode-utils':
-        specifier: 1.4.7
-        version: 1.4.7(vscode@1.1.37)
+        specifier: 1.4.8
+        version: 1.4.8(vscode@1.1.37)
       '@mermaid-js/examples':
         specifier: 0.0.1-beta.1
         version: 0.0.1-beta.1
@@ -664,8 +664,8 @@ packages:
   '@mermaid-chart/mermaid@11.16.0-b.1':
     resolution: {integrity: sha512-u2AcABWye/snv0eYfktgJBjZ1S2ZsRYxHAEhi6ajKXHOnvhadSdgzL/Q8LFWUBeFFWsiuc9AVTFStCXZPMzftQ==, tarball: https://npm.pkg.github.com/download/@mermaid-chart/mermaid/11.16.0-b.1/c07753d2bbfeb76649a68541961d728c91d2ae9d}
 
-  '@mermaid-chart/vscode-utils@1.4.7':
-    resolution: {integrity: sha512-aYIAJ8VpdjZZ9BsK2uRH9xC2diUh/zoIsm4Ma38o8tcZnKzFf7qnaB+fl9gWEY58hetxgMLVwcLeVL1lsDY9kQ==, tarball: https://npm.pkg.github.com/download/@mermaid-chart/vscode-utils/1.4.7/3389aab4b1bdb24f834b5856c9fe1f258b19be86}
+  '@mermaid-chart/vscode-utils@1.4.8':
+    resolution: {integrity: sha512-NbhCM4V28EXzhQDZo9JmMPjOgK39oMaLtIc8KfJ0I+g7RSJ68LHuZbu3w+1rhOWDR1SDU00qHhc8NK4f6ueqag==, tarball: https://npm.pkg.github.com/download/@mermaid-chart/vscode-utils/1.4.8/bed6f39eace08fd27fa04841ee2cdde7a47e0d03}
     engines: {node: '>=14.0.0', vscode: ^1.77.0}
     peerDependencies:
       vscode: '*'
@@ -3997,7 +3997,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mermaid-chart/vscode-utils@1.4.7(vscode@1.1.37)':
+  '@mermaid-chart/vscode-utils@1.4.8(vscode@1.1.37)':
     dependencies:
       '@vscode/chat-extension-utils': 0.0.0-alpha.5
       '@vscode/prompt-tsx': 0.3.0-alpha.24

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 11.16.0-b.1
         version: 11.16.0-b.1
       '@mermaid-chart/vscode-utils':
-        specifier: 1.4.6
-        version: 1.4.6(vscode@1.1.37)
+        specifier: 1.4.7
+        version: 1.4.7(vscode@1.1.37)
       '@mermaid-js/examples':
         specifier: 0.0.1-beta.1
         version: 0.0.1-beta.1
@@ -664,8 +664,8 @@ packages:
   '@mermaid-chart/mermaid@11.16.0-b.1':
     resolution: {integrity: sha512-u2AcABWye/snv0eYfktgJBjZ1S2ZsRYxHAEhi6ajKXHOnvhadSdgzL/Q8LFWUBeFFWsiuc9AVTFStCXZPMzftQ==, tarball: https://npm.pkg.github.com/download/@mermaid-chart/mermaid/11.16.0-b.1/c07753d2bbfeb76649a68541961d728c91d2ae9d}
 
-  '@mermaid-chart/vscode-utils@1.4.6':
-    resolution: {integrity: sha512-3oFcgI8q2zgKQpZ3f+xKIlCajznSa8YrP/kd3sT+uNVmYz7FLbaVuuW3jNnb11WYwjy7gjyn5K2KPsvVJ7ZDkw==, tarball: https://npm.pkg.github.com/download/@mermaid-chart/vscode-utils/1.4.6/a2b32d998333ae455ada630976dab1dae8cc6b3a}
+  '@mermaid-chart/vscode-utils@1.4.7':
+    resolution: {integrity: sha512-aYIAJ8VpdjZZ9BsK2uRH9xC2diUh/zoIsm4Ma38o8tcZnKzFf7qnaB+fl9gWEY58hetxgMLVwcLeVL1lsDY9kQ==, tarball: https://npm.pkg.github.com/download/@mermaid-chart/vscode-utils/1.4.7/3389aab4b1bdb24f834b5856c9fe1f258b19be86}
     engines: {node: '>=14.0.0', vscode: ^1.77.0}
     peerDependencies:
       vscode: '*'
@@ -3997,7 +3997,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mermaid-chart/vscode-utils@1.4.6(vscode@1.1.37)':
+  '@mermaid-chart/vscode-utils@1.4.7(vscode@1.1.37)':
     dependencies:
       '@vscode/chat-extension-utils': 0.0.0-alpha.5
       '@vscode/prompt-tsx': 0.3.0-alpha.24

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -242,11 +242,82 @@ class Analytics {
     );
   }
 
-  // File sync / connect
+  // File sync / connect — fired when a connected diagram has remote changes and the
+  // pull / force-push prompt is shown, not on every save of a Mermaid file.
+  public trackRemoteSync() {
+    this.sendEvent(
+      "VS Code Remote Sync",
+      "VS_CODE_PLUGIN_REMOTE_SYNC",
+    );
+  }
+
   public trackConnectDiagramToMermaidChart() {
     this.sendEvent(
       "VS Code Connect Diagram To Mermaid Chart",
       "VS_CODE_PLUGIN_CONNECT_DIAGRAM",
+    );
+  }
+
+  public trackConnectGitHub() {
+    this.sendEvent(
+      "VS Code Connect GitHub",
+      "VS_CODE_PLUGIN_CONNECT_GITHUB",
+    );
+  }
+
+  public trackDisconnectGitHub() {
+    this.sendEvent(
+      "VS Code Disconnect GitHub",
+      "VS_CODE_PLUGIN_DISCONNECT_GITHUB",
+    );
+  }
+
+  public trackAppReviewAccept() {
+    this.sendEvent(
+      "VS Code App Review Accept",
+      "VS_CODE_PLUGIN_APP_REVIEW_ACCEPT",
+    );
+  }
+
+  public trackAppReviewReject() {
+    this.sendEvent(
+      "VS Code App Review Reject",
+      "VS_CODE_PLUGIN_APP_REVIEW_REJECT",
+    );
+  }
+
+  public trackAppReviewReturnedToReview() {
+    this.sendEvent(
+      "VS Code App Review Returned To Review State",
+      "VS_CODE_PLUGIN_APP_REVIEW_RETURNED_TO_REVIEW",
+    );
+  }
+
+  public trackAppReviewCommit() {
+    this.sendEvent(
+      "VS Code App Review Commit",
+      "VS_CODE_PLUGIN_APP_REVIEW_COMMIT",
+    );
+  }
+
+  public trackOpenReviewUI() {
+    this.sendEvent(
+      "VS Code Open Review UI",
+      "VS_CODE_PLUGIN_OPEN_REVIEW_UI",
+    );
+  }
+
+  public trackOpenCodeDiff() {
+    this.sendEvent(
+      "VS Code Open Code Diff",
+      "VS_CODE_PLUGIN_OPEN_CODE_DIFF",
+    );
+  }
+
+  public trackOpenDiagramDiff() {
+    this.sendEvent(
+      "VS Code Open Diagram Diff",
+      "VS_CODE_PLUGIN_OPEN_DIAGRAM_DIFF",
     );
   }
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -5,6 +5,8 @@ import * as packageJson from '../package.json';
 export type LoginTrigger = 'mermaid-sidebar' | 'preview-repair' | 'pre-commit' | 'review-bulk-action' | 'connect-diagram';
 export type UpgradeFeature = 'repair' | 'regenerate' | 'add_diagram' | 'duplicate_diagram' | 'connect_diagram';
 
+export type OnCommitGenerateDecision = 'accepted' | 'dismissed';
+
 export interface PulseEventOptions {
   errorMessage?: string;
   diagramType?: string;
@@ -13,6 +15,7 @@ export interface PulseEventOptions {
   feature?: UpgradeFeature;
   pluginSource?: 'vsCode';
   source?: 'login' | 'signup';
+  decision?: OnCommitGenerateDecision;
 }
 
 class Analytics {
@@ -115,6 +118,22 @@ class Analytics {
     this.sendEvent(
       "VS Code Pre-Commit Diagram Regenerate",
       "VS_CODE_PLUGIN_PRE_COMMIT_DIAGRAM_REGENERATE",
+    );
+  }
+
+  // On-commit generate (create diagram from unlinked staged files)
+  public trackOnCommitDiagramGenerateShown() {
+    this.sendEvent(
+      "VS Code On-Commit Diagram Generate Show",
+      "VS_CODE_PLUGIN_ON_COMMIT_DIAGRAM_GENERATE_SHOW",
+    );
+  }
+
+  public trackOnCommitDiagramGenerationDecision(decision: OnCommitGenerateDecision) {
+    this.sendEvent(
+      "VS Code On-Commit Diagram Generation Decision",
+      "VS_CODE_PLUGIN_ON_COMMIT_DIAGRAM_GENERATION_DECISION",
+      { decision },
     );
   }
 

--- a/src/appDiffViewProvider.ts
+++ b/src/appDiffViewProvider.ts
@@ -6,6 +6,7 @@ import { AppReviewIntegration, type ReviewFileMapping } from "./appReviewIntegra
 import { pathsEqualAbsolute } from "./appReviewPaths";
 import { AppFileDecorationProvider } from "./appFileDecorationProvider";
 import { openAppReviewDiagramSurface } from "./commercial/sync/diagramDiffView";
+import analytics from "./analytics";
 
 function fileUrisMatch(a: vscode.Uri, b: vscode.Uri, integration: AppReviewIntegration): boolean {
   if (a.scheme !== b.scheme) {
@@ -77,10 +78,10 @@ export class AppDiffViewProvider {
     private readonly fileDecorationProvider: AppFileDecorationProvider
   ) {}
 
-  async restoreAppProposalAndPending(fileUri: vscode.Uri): Promise<void> {
+  async restoreAppProposalAndPending(fileUri: vscode.Uri): Promise<boolean> {
     const mapping = this.appReviewIntegration.getReviewMapping(fileUri.fsPath);
     if (!mapping) {
-      return;
+      return false;
     }
     try {
       await this.cancelSessionsForOriginal(mapping.originalFilePath);
@@ -89,7 +90,7 @@ export class AppDiffViewProvider {
         vscode.window.showErrorMessage(
           `Could not load Mermaid Sync app proposal from GitHub for ${path.basename(mapping.originalFilePath)}.`
         );
-        return;
+        return false;
       }
       await this.replaceOriginalFileContent(mapping.originalFilePath, botContent);
       mapping.status = "pending";
@@ -98,8 +99,10 @@ export class AppDiffViewProvider {
       vscode.window.showInformationMessage(
         `Restored Mermaid Sync app proposal for ${path.basename(mapping.originalFilePath)}. Status: review pending.`
       );
+      return true;
     } catch (error) {
       vscode.window.showErrorMessage(`Error restoring Mermaid Sync app proposal: ${error}`);
+      return false;
     }
   }
 
@@ -324,6 +327,8 @@ export class AppDiffViewProvider {
       vscode.window.showErrorMessage("No active Mermaid Sync app review for this file.");
       return;
     }
+
+    analytics.trackOpenCodeDiff();
 
     const panelSession = this.sessionsByOriginal.get(path.normalize(mapping.originalFilePath));
     const modifiedUri = vscode.Uri.file(mapping.originalFilePath);

--- a/src/appReviewFeature.ts
+++ b/src/appReviewFeature.ts
@@ -269,32 +269,40 @@ export class AppReviewFeature implements vscode.Disposable {
           vscode.window.showWarningMessage("Open a diagram file (.mmd) to review changes.");
           return;
         }
+        analytics.trackOpenReviewUI();
         await this.diffViewProvider.showAppDiff(target);
       }),
       vscode.commands.registerCommand("mermaidChart.appReviewAccept", async (arg) => {
         const target = this.resolveReviewTarget(arg);
         if (target) {
-          await this.diffViewProvider.acceptAppChanges(target);
+          if (await this.diffViewProvider.acceptAppChanges(target)) {
+            analytics.trackAppReviewAccept();
+          }
           await this.gitStatusTracker.refreshPath(target.fsPath);
         }
       }),
       vscode.commands.registerCommand("mermaidChart.appReviewReject", async (arg) => {
         const target = this.resolveReviewTarget(arg);
         if (target) {
-          await this.diffViewProvider.rejectAppChanges(target);
+          if (await this.diffViewProvider.rejectAppChanges(target)) {
+            analytics.trackAppReviewReject();
+          }
           await this.gitStatusTracker.refreshPath(target.fsPath);
         }
       }),
       vscode.commands.registerCommand("mermaidChart.appReviewBackToPending", async (arg) => {
         const target = this.resolveReviewTarget(arg);
         if (target) {
-          await this.diffViewProvider.restoreAppProposalAndPending(target);
+          if (await this.diffViewProvider.restoreAppProposalAndPending(target)) {
+            analytics.trackAppReviewReturnedToReview();
+          }
           await this.gitStatusTracker.refreshPath(target.fsPath);
         }
       }),
-      vscode.commands.registerCommand("mermaidChart.commitAppReview", (uri: vscode.Uri) =>
-        this.commitWorkflow.commitAppReview(uri)
-      ),
+      vscode.commands.registerCommand("mermaidChart.commitAppReview", (uri: vscode.Uri) => {
+        analytics.trackAppReviewCommit();
+        return this.commitWorkflow.commitAppReview(uri);
+      }),
       vscode.commands.registerCommand("mermaidChart.closeAppReview", async (arg) => {
         const target = this.resolveReviewTarget(arg);
         if (!target) {

--- a/src/appReviewIntegration.ts
+++ b/src/appReviewIntegration.ts
@@ -372,6 +372,7 @@ export class AppReviewIntegration {
       if (!authed) {
         throw new Error("GitHub sign-in was cancelled.");
       }
+      analytics.trackConnectGitHub();
       vscode.window.showInformationMessage("Connected to GitHub successfully.");
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -390,6 +391,7 @@ export class AppReviewIntegration {
     } catch {
       /* ignore — preference may not be set */
     }
+    analytics.trackDisconnectGitHub();
     vscode.window.showInformationMessage(
       "Disconnected from GitHub. Run \"MermaidChart: Connect GitHub\" to reconnect."
     );

--- a/src/commercial/sync/createDiagramFromStage.ts
+++ b/src/commercial/sync/createDiagramFromStage.ts
@@ -1,18 +1,15 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { extractMetadataFromCode } from '../../frontmatter';
+import { extractMetadataFromCode, resolveReferencePath } from '../../frontmatter';
 import analytics from '../../analytics';
 import {
   recordInteraction,
   shouldShowPrompt,
 } from './interactionCooldown';
-import {
-  isCodingSourceFile,
-  resolveReferencePath,
-} from './gitStageHelpers';
+import { isCodingSourceFile } from './gitStageHelpers';
 
 /** Set to false before release — when true, toast shows every time (no globalState). */
-const createDiagramFromStageAlwaysShowForTesting = true;
+const createDiagramFromStageAlwaysShowForTesting = false;
 
 const PROMPT_STATE_KEY = 'createDiagramFromStage.prompt';
 

--- a/src/commercial/sync/createDiagramFromStage.ts
+++ b/src/commercial/sync/createDiagramFromStage.ts
@@ -1,0 +1,139 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { extractMetadataFromCode } from '../../frontmatter';
+import analytics from '../../analytics';
+import {
+  recordInteraction,
+  shouldShowPrompt,
+} from './interactionCooldown';
+import {
+  isCodingSourceFile,
+  resolveReferencePath,
+} from './gitStageHelpers';
+
+/** Set to false before release — when true, toast shows every time (no globalState). */
+const createDiagramFromStageAlwaysShowForTesting = true;
+
+const PROMPT_STATE_KEY = 'createDiagramFromStage.prompt';
+
+/**
+ * Soft offer to generate a new diagram from staged coding files that have no
+ * linked Mermaid diagram. Separate from staging regenerate (existing diagrams).
+ */
+export class CreateDiagramFromStageService {
+  private static extensionContext: vscode.ExtensionContext | undefined;
+
+  static register(context: vscode.ExtensionContext): void {
+    CreateDiagramFromStageService.extensionContext = context;
+  }
+
+  /**
+   * Offer generate-from-code for staged coding files that are not referenced
+   * by any workspace diagram. Never blocks staging/commit.
+   */
+  static async maybeOffer(
+    workspaceFolder: vscode.WorkspaceFolder,
+    stagedSourcePaths: string[],
+  ): Promise<void> {
+    const context = CreateDiagramFromStageService.extensionContext;
+    if (!context) {
+      return;
+    }
+
+    const enabled = vscode.workspace
+      .getConfiguration('mermaidChart')
+      .get<boolean>('createDiagramFromStage.enabled', true);
+    if (!enabled) {
+      return;
+    }
+
+    const cooldownOpts = {
+      globalState: context.globalState,
+      stateKeyPrefix: PROMPT_STATE_KEY,
+      alwaysShow: createDiagramFromStageAlwaysShowForTesting,
+      maxInteractionsBeforeCooldown: 2,
+    };
+
+    if (!shouldShowPrompt(cooldownOpts)) {
+      return;
+    }
+
+    const codingStaged = stagedSourcePaths.filter(isCodingSourceFile);
+    if (codingStaged.length === 0) {
+      return;
+    }
+
+    const referencedPaths = await CreateDiagramFromStageService.collectReferencedSourcePaths(
+      workspaceFolder,
+    );
+    const unlinked = codingStaged.filter(
+      (p) => !referencedPaths.has(path.normalize(p)),
+    );
+    if (unlinked.length === 0) {
+      return;
+    }
+
+    const fileNames = unlinked.map((p) => path.basename(p));
+    const namePreview =
+      fileNames.length <= 5
+        ? fileNames.join(', ')
+        : `${fileNames.slice(0, 5).join(', ')} (+${fileNames.length - 5} more)`;
+
+    analytics.trackOnCommitDiagramGenerateShown();
+
+    const pick = await vscode.window.showInformationMessage(
+      `New staged code has no Mermaid diagram ("${namePreview}").\n\nVisualize it with Generate Diagram From Code?`,
+      { modal: false },
+      'Generate',
+      'Not now',
+    );
+
+    const decision = pick === 'Generate' ? 'accepted' : 'dismissed';
+    analytics.trackOnCommitDiagramGenerationDecision(decision);
+    await recordInteraction(cooldownOpts);
+
+    if (pick !== 'Generate') {
+      return;
+    }
+
+    const uris = unlinked.map((p) => vscode.Uri.file(p));
+    await vscode.commands.executeCommand(
+      'mermaidChart.generateDiagramFromCode',
+      uris,
+    );
+  }
+
+  /** Absolute paths referenced by any .mmd/.mermaid frontmatter in the workspace. */
+  private static async collectReferencedSourcePaths(
+    workspaceFolder: vscode.WorkspaceFolder,
+  ): Promise<Set<string>> {
+    const referenced = new Set<string>();
+    const mmdUris = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(workspaceFolder, '**/*.{mmd,mermaid}'),
+    );
+
+    for (const mmdUri of mmdUris) {
+      try {
+        const bytes = await vscode.workspace.fs.readFile(mmdUri);
+        const text = Buffer.from(bytes).toString('utf-8');
+        const metadata = extractMetadataFromCode(text);
+        if (!metadata.references || metadata.references.length === 0) {
+          continue;
+        }
+        for (const ref of metadata.references) {
+          const refPath = resolveReferencePath(ref, workspaceFolder.uri.fsPath);
+          if (refPath) {
+            referenced.add(path.normalize(refPath));
+          }
+        }
+      } catch (error) {
+        console.error(
+          { mmdUri: mmdUri.fsPath, error },
+          'CreateDiagramFromStage: failed to read diagram file',
+        );
+      }
+    }
+
+    return referenced;
+  }
+}

--- a/src/commercial/sync/diagramDiffView.ts
+++ b/src/commercial/sync/diagramDiffView.ts
@@ -17,6 +17,7 @@ import {
 } from "./diagramDiffHighlighter";
 import { getThemeColors } from "../../../webview/src/themes/themeConfig";
 import { saveDiagramAsPng, saveDiagramAsSvg } from "../../services/renderService";
+import analytics from "../../analytics";
 
 const EXTENSION_ID = `${packageJson.publisher}.${packageJson.name}`;
 
@@ -235,6 +236,7 @@ export function openDiagramDiffWebviews(
   newContent: string,
   options?: DiagramDiffWebviewOptions,
 ): () => void {
+  analytics.trackOpenDiagramDiff();
   let panelCurrent: vscode.WebviewPanel | undefined;
   let panelUpdated: vscode.WebviewPanel | undefined;
   const disposables: vscode.Disposable[] = [];

--- a/src/commercial/sync/gitStageHelpers.ts
+++ b/src/commercial/sync/gitStageHelpers.ts
@@ -1,0 +1,146 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+export const GIT_TIMEOUT_MS = 5000;
+
+/** Coding extensions eligible for generate-from-code / create-from-stage. */
+export const CODING_FILE_EXTENSIONS = new Set([
+  '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs',
+  '.py', '.pyw', '.pyi',
+  '.java', '.kt', '.scala', '.groovy',
+  '.c', '.cpp', '.cc', '.cxx', '.h', '.hpp', '.hxx',
+  '.cs', '.vb', '.fs', '.fsx',
+  '.go',
+  '.rs',
+  '.php', '.phtml',
+  '.rb', '.rbx',
+  '.swift',
+  '.dart', '.lua', '.perl', '.pl', '.r', '.m', '.mm',
+  '.clj', '.cljs', '.elm', '.ex', '.exs', '.hs', '.jl',
+  '.nim', '.pas', '.pp', '.sh', '.bash', '.zsh', '.fish',
+  '.sql', '.ps1', '.psm1', '.psd1',
+]);
+
+export function isCodingSourceFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return ext !== '' && CODING_FILE_EXTENSIONS.has(ext);
+}
+
+/** Run a git command asynchronously. Returns stdout/stderr or null on failure. */
+export async function runGit(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string } | null> {
+  try {
+    const { stdout, stderr } = await execFileAsync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { stdout, stderr };
+  } catch (error) {
+    console.error({ cwd, args, error }, 'GitStageHelpers: git command failed');
+    return null;
+  }
+}
+
+/**
+ * Staged source file absolute paths (ACMR only), excluding .mmd/.mermaid.
+ * Returns null if git failed; empty array if nothing staged.
+ */
+export async function getStagedSourcePaths(
+  repoRoot: string,
+): Promise<string[] | null> {
+  const stagedResult = await runGit(
+    ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
+    repoRoot,
+  );
+  if (!stagedResult) {
+    return null;
+  }
+  const stagedOutput = stagedResult.stdout.trim();
+  if (!stagedOutput) {
+    return [];
+  }
+  return stagedOutput
+    .split('\n')
+    .filter(Boolean)
+    .map((p) => path.join(repoRoot, p))
+    .filter((p) => !p.endsWith('.mmd') && !p.endsWith('.mermaid'));
+}
+
+/**
+ * Extract the resolved absolute file path from a reference string like "File: /src/auth.ts".
+ *
+ * Convention: a leading "/" in a reference means workspace-relative (not POSIX root).
+ * Only Windows drive paths (e.g. C:\...) are treated as truly absolute and used as-is.
+ */
+export function resolveReferencePath(
+  reference: string,
+  workspacePath: string,
+): string | undefined {
+  const match = reference.match(/File: (.*?)(\s|$|\()/);
+  if (!match) return undefined;
+
+  const filePath = match[1].trim();
+  if (!filePath.includes('/') && !filePath.includes('\\')) return undefined;
+
+  if (/^[a-zA-Z]:[\\/]/.test(filePath)) {
+    return path.normalize(filePath);
+  }
+
+  if (workspacePath) {
+    const relative = filePath.replace(/^[/\\]+/, '');
+    return path.normalize(path.join(workspacePath, relative));
+  }
+
+  return path.normalize(filePath);
+}
+
+/** Maps a unified diff (+/-/ ) into the [ADDED]/[REMOVED]/[CONTEXT] format. */
+export function buildSourceFileContext(filePath: string, unifiedDiff: string): string {
+  const lines: string[] = [];
+  lines.push('=== DETAILED CHANGE SUMMARY ===');
+  lines.push('Source File Changes:');
+  lines.push(`MODIFIED: ${filePath} (changes detected)`);
+  lines.push('');
+
+  for (const line of unifiedDiff.replace(/\r\n?/g, '\n').split('\n')) {
+    if (
+      line.startsWith('--- ') ||
+      line.startsWith('+++ ') ||
+      line.startsWith('diff ') ||
+      line.startsWith('index ') ||
+      line.startsWith('@@')
+    ) {
+      continue;
+    }
+    if (line.startsWith('+')) {
+      lines.push(`[ADDED]   ${line.slice(1)}`);
+    } else if (line.startsWith('-')) {
+      lines.push(`[REMOVED] ${line.slice(1)}`);
+    } else if (line.startsWith(' ')) {
+      lines.push(`[CONTEXT] ${line.slice(1)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export async function readFileAsAddedContext(
+  absPath: string,
+  relPath: string,
+): Promise<string | undefined> {
+  try {
+    const content = (await fs.promises.readFile(absPath, 'utf-8')).replace(/\r\n?/g, '\n');
+    const lines = content.split('\n').map((l) => `[ADDED]   ${l}`).join('\n');
+    return `=== DETAILED CHANGE SUMMARY ===\nSource File Changes:\nADDED: ${relPath} (new file)\n\n${lines}`;
+  } catch (error) {
+    console.error({ absPath, error }, 'GitStageHelpers: failed to read source file');
+    return undefined;
+  }
+}

--- a/src/commercial/sync/gitStageHelpers.ts
+++ b/src/commercial/sync/gitStageHelpers.ts
@@ -4,7 +4,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
-export const GIT_TIMEOUT_MS = 5000;
+const GIT_TIMEOUT_MS = 5000;
 
 /** Coding extensions eligible for generate-from-code / create-from-stage. */
 export const CODING_FILE_EXTENSIONS = new Set([
@@ -29,6 +29,10 @@ export function isCodingSourceFile(filePath: string): boolean {
   return ext !== '' && CODING_FILE_EXTENSIONS.has(ext);
 }
 
+export function isMermaidFile(filePath: string): boolean {
+  return filePath.endsWith('.mmd') || filePath.endsWith('.mermaid');
+}
+
 /** Run a git command asynchronously. Returns stdout/stderr or null on failure. */
 export async function runGit(
   args: string[],
@@ -49,10 +53,14 @@ export async function runGit(
 }
 
 /**
- * Staged source file absolute paths (ACMR only), excluding .mmd/.mermaid.
+ * All staged file absolute paths (ACMR only — Added, Copied, Modified, Renamed).
+ * Deleted files are excluded so unstaging/discarding changes doesn't trigger a popup.
  * Returns null if git failed; empty array if nothing staged.
+ *
+ * Callers split this into source vs .mmd/.mermaid themselves, so a single git
+ * invocation backs every consumer of one staging event.
  */
-export async function getStagedSourcePaths(
+export async function getStagedPaths(
   repoRoot: string,
 ): Promise<string[] | null> {
   const stagedResult = await runGit(
@@ -69,36 +77,7 @@ export async function getStagedSourcePaths(
   return stagedOutput
     .split('\n')
     .filter(Boolean)
-    .map((p) => path.join(repoRoot, p))
-    .filter((p) => !p.endsWith('.mmd') && !p.endsWith('.mermaid'));
-}
-
-/**
- * Extract the resolved absolute file path from a reference string like "File: /src/auth.ts".
- *
- * Convention: a leading "/" in a reference means workspace-relative (not POSIX root).
- * Only Windows drive paths (e.g. C:\...) are treated as truly absolute and used as-is.
- */
-export function resolveReferencePath(
-  reference: string,
-  workspacePath: string,
-): string | undefined {
-  const match = reference.match(/File: (.*?)(\s|$|\()/);
-  if (!match) return undefined;
-
-  const filePath = match[1].trim();
-  if (!filePath.includes('/') && !filePath.includes('\\')) return undefined;
-
-  if (/^[a-zA-Z]:[\\/]/.test(filePath)) {
-    return path.normalize(filePath);
-  }
-
-  if (workspacePath) {
-    const relative = filePath.replace(/^[/\\]+/, '');
-    return path.normalize(path.join(workspacePath, relative));
-  }
-
-  return path.normalize(filePath);
+    .map((p) => path.join(repoRoot, p));
 }
 
 /** Maps a unified diff (+/-/ ) into the [ADDED]/[REMOVED]/[CONTEXT] format. */

--- a/src/commercial/sync/interactionCooldown.ts
+++ b/src/commercial/sync/interactionCooldown.ts
@@ -1,0 +1,77 @@
+import type * as vscode from 'vscode';
+
+const DEFAULT_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000; // ~1 month
+
+export interface InteractionCooldownOptions {
+  globalState: vscode.Memento;
+  /** Unique prefix for globalState keys, e.g. "createDiagramFromStage.prompt". */
+  stateKeyPrefix: string;
+  /**
+   * When true (dev/testing): always allow the prompt and never read/write globalState.
+   * When false (production): enforce interaction count + cooldown.
+   */
+  alwaysShow: boolean;
+  /** How many recorded interactions before starting cooldown. Default 1. */
+  maxInteractionsBeforeCooldown?: number;
+  cooldownMs?: number;
+}
+
+interface CooldownState {
+  interactionCount: number;
+  cooldownUntil: number;
+}
+
+function stateKeys(prefix: string) {
+  return {
+    interactionCount: `${prefix}.interactionCount`,
+    cooldownUntil: `${prefix}.cooldownUntil`,
+  };
+}
+
+function readState(
+  globalState: vscode.Memento,
+  prefix: string,
+): CooldownState {
+  const keys = stateKeys(prefix);
+  return {
+    interactionCount: globalState.get<number>(keys.interactionCount, 0),
+    cooldownUntil: globalState.get<number>(keys.cooldownUntil, 0),
+  };
+}
+
+/** Returns true when the prompt is allowed to show. */
+export function shouldShowPrompt(options: InteractionCooldownOptions): boolean {
+  if (options.alwaysShow) {
+    return true;
+  }
+  const { cooldownUntil } = readState(options.globalState, options.stateKeyPrefix);
+  return Date.now() >= cooldownUntil;
+}
+
+/**
+ * Record one user-facing interaction with the prompt.
+ * After `maxInteractionsBeforeCooldown` interactions, starts a cooldown window.
+ */
+export async function recordInteraction(
+  options: InteractionCooldownOptions,
+): Promise<void> {
+  if (options.alwaysShow) {
+    return;
+  }
+
+  const max =
+    options.maxInteractionsBeforeCooldown !== undefined
+      ? options.maxInteractionsBeforeCooldown
+      : 1;
+  const cooldownMs = options.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+  const keys = stateKeys(options.stateKeyPrefix);
+  const current = readState(options.globalState, options.stateKeyPrefix);
+  const nextCount = current.interactionCount + 1;
+
+  if (nextCount >= max) {
+    await options.globalState.update(keys.interactionCount, 0);
+    await options.globalState.update(keys.cooldownUntil, Date.now() + cooldownMs);
+  } else {
+    await options.globalState.update(keys.interactionCount, nextCount);
+  }
+}

--- a/src/commercial/sync/stagingSyncService.ts
+++ b/src/commercial/sync/stagingSyncService.ts
@@ -1,96 +1,19 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { extractMetadataFromCode } from '../../frontmatter';
 import { MermaidChartAuthenticationProvider } from '../../mermaidChartAuthenticationProvider';
 import { setPendingLoginTrigger } from '../../loginTrigger';
 import type { MermaidChartVSCode } from '../../mermaidChartVSCode';
 import analytics from '../../analytics';
-
-const execFileAsync = promisify(execFile);
-const GIT_TIMEOUT_MS = 5000;
-
-/** Maps a unified diff (+/-/ ) into the [ADDED]/[REMOVED]/[CONTEXT] format. */
-function buildSourceFileContext(filePath: string, unifiedDiff: string): string {
-  const lines: string[] = [];
-  lines.push('=== DETAILED CHANGE SUMMARY ===');
-  lines.push('Source File Changes:');
-  lines.push(`MODIFIED: ${filePath} (changes detected)`);
-  lines.push('');
-
-  for (const line of unifiedDiff.replace(/\r\n?/g, '\n').split('\n')) {
-    // Skip file header lines (--- a/... +++ b/...) and hunk headers (@@ ... @@)
-    if (
-      line.startsWith('--- ') ||
-      line.startsWith('+++ ') ||
-      line.startsWith('diff ') ||
-      line.startsWith('index ') ||
-      line.startsWith('@@')
-    ) {
-      continue;
-    }
-    if (line.startsWith('+')) {
-      lines.push(`[ADDED]   ${line.slice(1)}`);
-    } else if (line.startsWith('-')) {
-      lines.push(`[REMOVED] ${line.slice(1)}`);
-    } else if (line.startsWith(' ')) {
-      lines.push(`[CONTEXT] ${line.slice(1)}`);
-    }
-    // empty lines at end of diff — skip
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * Extract the resolved absolute file path from a reference string like "File: /src/auth.ts".
- *
- * Convention: a leading "/" in a reference means workspace-relative (not POSIX root).
- * Only Windows drive paths (e.g. C:\...) are treated as truly absolute and used as-is.
- * On POSIX, path.isAbsolute('/src/auth.ts') returns true but that path is still
- * workspace-relative by this codebase's convention, so we must not use path.isAbsolute.
- */
-function resolveReferencePath(reference: string, workspacePath: string): string | undefined {
-  const match = reference.match(/File: (.*?)(\s|$|\()/);
-  if (!match) return undefined;
-
-  const filePath = match[1].trim();
-  if (!filePath.includes('/') && !filePath.includes('\\')) return undefined;
-
-  // Windows absolute path (e.g. C:\proj\src\auth.ts) — use as-is.
-  if (/^[a-zA-Z]:[\\/]/.test(filePath)) {
-    return path.normalize(filePath);
-  }
-
-  if (workspacePath) {
-    // Strip any leading slashes/backslashes (workspace-relative convention).
-    const relative = filePath.replace(/^[/\\]+/, '');
-    return path.normalize(path.join(workspacePath, relative));
-  }
-
-  return path.normalize(filePath);
-}
-
-/** Run a git command asynchronously. Returns stdout/stderr or null on failure. */
-async function runGit(
-  args: string[],
-  cwd: string,
-): Promise<{ stdout: string; stderr: string } | null> {
-  try {
-    const { stdout, stderr } = await execFileAsync('git', args, {
-      cwd,
-      encoding: 'utf-8',
-      timeout: GIT_TIMEOUT_MS,
-      maxBuffer: 10 * 1024 * 1024,
-    });
-    return { stdout, stderr };
-  } catch (error) {
-    console.error({ cwd, args, error }, 'PreCommitSync: git command failed');
-    return null;
-  }
-}
+import { CreateDiagramFromStageService } from './createDiagramFromStage';
+import {
+  buildSourceFileContext,
+  getStagedSourcePaths,
+  readFileAsAddedContext,
+  resolveReferencePath,
+  runGit,
+} from './gitStageHelpers';
 
 /** Result of a single diagram's staged-change analysis. */
 interface AffectedDiagram {
@@ -99,12 +22,19 @@ interface AffectedDiagram {
   stagedSourceFiles: string[]; // absolute paths of the matched staged files
 }
 
-export class PreCommitSyncService {
+/**
+ * Watches git staging and offers:
+ * 1. Regenerate — staged sources already linked to diagrams
+ * 2. Create diagram from stage — staged coding sources with no linked diagram
+ */
+export class StagingSyncService {
   private static debounceTimers = new Map<string, NodeJS.Timeout>();
   private static folderWatchers = new Map<string, fs.FSWatcher>();
   private static retryIntervals = new Map<string, NodeJS.Timeout>();
 
   static register(context: vscode.ExtensionContext, mcAPI: MermaidChartVSCode): void {
+    CreateDiagramFromStageService.register(context);
+
     // vscode.workspace.createFileSystemWatcher excludes .git/** by default, so
     // we use Node's fs.watch() directly.
     // IMPORTANT: git never modifies .git/index in place — it writes to
@@ -119,20 +49,20 @@ export class PreCommitSyncService {
         // .git doesn't exist yet (folder opened before git init).
         // Poll every 5s; once it appears, set up the real watcher.
         const retryInterval = setInterval(() => {
-          if (fs.existsSync(gitDir) && !PreCommitSyncService.folderWatchers.has(folderPath)) {
+          if (fs.existsSync(gitDir) && !StagingSyncService.folderWatchers.has(folderPath)) {
             clearInterval(retryInterval);
-            PreCommitSyncService.retryIntervals.delete(folderPath);
+            StagingSyncService.retryIntervals.delete(folderPath);
             setupWatcher(workspaceFolder);
           }
         }, 5000);
-        PreCommitSyncService.retryIntervals.set(folderPath, retryInterval);
+        StagingSyncService.retryIntervals.set(folderPath, retryInterval);
 
         context.subscriptions.push({
           dispose: () => {
-            const interval = PreCommitSyncService.retryIntervals.get(folderPath);
+            const interval = StagingSyncService.retryIntervals.get(folderPath);
             if (interval) {
               clearInterval(interval);
-              PreCommitSyncService.retryIntervals.delete(folderPath);
+              StagingSyncService.retryIntervals.delete(folderPath);
             }
           },
         });
@@ -141,26 +71,26 @@ export class PreCommitSyncService {
 
       const nodeWatcher = fs.watch(gitDir, (_eventType, filename) => {
         if (filename === 'index') {
-          PreCommitSyncService.onIndexChanged(workspaceFolder, mcAPI);
+          StagingSyncService.onIndexChanged(workspaceFolder, mcAPI);
         }
       });
 
-      PreCommitSyncService.folderWatchers.set(folderPath, nodeWatcher);
+      StagingSyncService.folderWatchers.set(folderPath, nodeWatcher);
 
       // Look up the watcher from the map at dispose time so teardownWatcher
       // (folder removal) and subscription dispose (extension deactivate) don't
       // double-close the same watcher instance.
       context.subscriptions.push({
         dispose: () => {
-          const watcher = PreCommitSyncService.folderWatchers.get(folderPath);
+          const watcher = StagingSyncService.folderWatchers.get(folderPath);
           if (watcher) {
             watcher.close();
-            PreCommitSyncService.folderWatchers.delete(folderPath);
+            StagingSyncService.folderWatchers.delete(folderPath);
           }
-          const timer = PreCommitSyncService.debounceTimers.get(folderPath);
+          const timer = StagingSyncService.debounceTimers.get(folderPath);
           if (timer) {
             clearTimeout(timer);
-            PreCommitSyncService.debounceTimers.delete(folderPath);
+            StagingSyncService.debounceTimers.delete(folderPath);
           }
         },
       });
@@ -168,20 +98,20 @@ export class PreCommitSyncService {
 
     const teardownWatcher = (workspaceFolder: vscode.WorkspaceFolder) => {
       const folderPath = workspaceFolder.uri.fsPath;
-      const watcher = PreCommitSyncService.folderWatchers.get(folderPath);
+      const watcher = StagingSyncService.folderWatchers.get(folderPath);
       if (watcher) {
         watcher.close();
-        PreCommitSyncService.folderWatchers.delete(folderPath);
+        StagingSyncService.folderWatchers.delete(folderPath);
       }
-      const timer = PreCommitSyncService.debounceTimers.get(folderPath);
+      const timer = StagingSyncService.debounceTimers.get(folderPath);
       if (timer) {
         clearTimeout(timer);
-        PreCommitSyncService.debounceTimers.delete(folderPath);
+        StagingSyncService.debounceTimers.delete(folderPath);
       }
-      const retryInterval = PreCommitSyncService.retryIntervals.get(folderPath);
+      const retryInterval = StagingSyncService.retryIntervals.get(folderPath);
       if (retryInterval) {
         clearInterval(retryInterval);
-        PreCommitSyncService.retryIntervals.delete(folderPath);
+        StagingSyncService.retryIntervals.delete(folderPath);
       }
     };
 
@@ -199,14 +129,14 @@ export class PreCommitSyncService {
     mcAPI: MermaidChartVSCode,
   ): void {
     const key = workspaceFolder.uri.fsPath;
-    const existing = PreCommitSyncService.debounceTimers.get(key);
+    const existing = StagingSyncService.debounceTimers.get(key);
     if (existing) clearTimeout(existing);
 
     const timer = setTimeout(
-      () => PreCommitSyncService.handleStagingChange(workspaceFolder, mcAPI),
+      () => StagingSyncService.handleStagingChange(workspaceFolder, mcAPI),
       300,
     );
-    PreCommitSyncService.debounceTimers.set(key, timer);
+    StagingSyncService.debounceTimers.set(key, timer);
   }
 
   private static async handleStagingChange(
@@ -215,42 +145,52 @@ export class PreCommitSyncService {
   ): Promise<void> {
     const repoRoot = workspaceFolder.uri.fsPath;
 
-    // Check if feature is enabled in settings
-    const enabled = vscode.workspace
-      .getConfiguration('mermaidChart')
-      .get<boolean>('preCommitSync.enabled', true);
-    if (!enabled) return;
-
-    // Get staged file paths via git directly — no VSCode Git API dependency.
-    // --diff-filter=ACMR: only Added, Copied, Modified, Renamed files.
-    // Excludes Deleted (D) so unstaging/discarding changes doesn't trigger the popup.
-    const stagedResult = await runGit(
-      ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
-      repoRoot,
-    );
-    if (!stagedResult) {
-      console.error({ repoRoot }, 'PreCommitSync: failed to get staged files');
+    const sourceStagedPaths = await getStagedSourcePaths(repoRoot);
+    if (sourceStagedPaths === null) {
+      console.error({ repoRoot }, 'StagingSync: failed to get staged files');
       return;
     }
-    const stagedOutput = stagedResult.stdout.trim();
-    if (!stagedOutput) return;
-    const allStagedPaths = stagedOutput
-      .split('\n')
-      .filter(Boolean)
-      .map((p) => path.join(repoRoot, p));
+    if (sourceStagedPaths.length === 0) {
+      return;
+    }
 
-    // Ignore staging events that only contain .mmd/.mermaid files themselves —
-    // those aren't source files that drive diagram regeneration.
-    const sourceStagedPaths = allStagedPaths.filter(
-      (p) => !p.endsWith('.mmd') && !p.endsWith('.mermaid'),
-    );
-    if (sourceStagedPaths.length === 0) return;
+    // Path 1 — regenerate existing linked diagrams (preCommitSync.enabled)
+    const regenerateEnabled = vscode.workspace
+      .getConfiguration('mermaidChart')
+      .get<boolean>('preCommitSync.enabled', true);
+    if (regenerateEnabled) {
+      await StagingSyncService.handleRegeneratePath(
+        workspaceFolder,
+        sourceStagedPaths,
+        mcAPI,
+      );
+    }
+
+    // Path 2 — create diagram from stage for unlinked staged coding files
+    await CreateDiagramFromStageService.maybeOffer(workspaceFolder, sourceStagedPaths);
+  }
+
+  private static async handleRegeneratePath(
+    workspaceFolder: vscode.WorkspaceFolder,
+    sourceStagedPaths: string[],
+    mcAPI: MermaidChartVSCode,
+  ): Promise<void> {
+    const repoRoot = workspaceFolder.uri.fsPath;
 
     // Build a set of .mmd/.mermaid paths that should be skipped:
     //   1. Already staged — regenerated and added by the user.
     //   2. Has unstaged modifications — regenerated but not yet staged, OR was
     //      staged then unstaged (git restore --staged). In both cases the
     //      regenerated content is already on disk; no popup needed.
+    const allStagedResult = await runGit(
+      ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
+      repoRoot,
+    );
+    const allStagedPaths = (allStagedResult?.stdout.trim() ?? '')
+      .split('\n')
+      .filter(Boolean)
+      .map((p) => path.join(repoRoot, p));
+
     const stagedMmdPaths = new Set(
       allStagedPaths.filter((p) => p.endsWith('.mmd') || p.endsWith('.mermaid')),
     );
@@ -276,14 +216,14 @@ export class PreCommitSyncService {
         cancellable: false,
       },
       async () => {
-        affected = await PreCommitSyncService.findAffectedDiagrams(
+        affected = await StagingSyncService.findAffectedDiagrams(
           workspaceFolder,
           sourceStagedPaths,
           stagedMmdPaths,
         );
         if (affected.length === 0) return;
 
-        sourceFilesContext = await PreCommitSyncService.buildSourceFilesContext(
+        sourceFilesContext = await StagingSyncService.buildSourceFilesContext(
           repoRoot,
           affected,
         );
@@ -292,7 +232,7 @@ export class PreCommitSyncService {
 
     // Phase 2: show the info toast only after the scanning notification is gone.
     if (affected.length > 0) {
-      await PreCommitSyncService.showSyncPopup(affected, sourceFilesContext, mcAPI);
+      await StagingSyncService.showSyncPopup(affected, sourceFilesContext, mcAPI);
     }
   }
 
@@ -347,7 +287,7 @@ export class PreCommitSyncService {
       } catch (error) {
         console.error(
           { mmdUri: mmdUri.fsPath, error },
-          'PreCommitSync: failed to read diagram file',
+          'StagingSync: failed to read diagram file',
         );
       }
     }
@@ -398,15 +338,9 @@ export class PreCommitSyncService {
         contextMap.set(absPath, buildSourceFileContext(relPath, diff));
       } else {
         // New file — no HEAD version, send full content as [ADDED]
-        try {
-          const content = (await fs.promises.readFile(absPath, 'utf-8')).replace(/\r\n?/g, '\n');
-          const lines = content.split('\n').map((l) => `[ADDED]   ${l}`).join('\n');
-          contextMap.set(
-            absPath,
-            `=== DETAILED CHANGE SUMMARY ===\nSource File Changes:\nADDED: ${relPath} (new file)\n\n${lines}`,
-          );
-        } catch (error) {
-          console.error({ absPath, error }, 'PreCommitSync: failed to read source file');
+        const added = await readFileAsAddedContext(absPath, relPath);
+        if (added) {
+          contextMap.set(absPath, added);
         }
       }
     }

--- a/src/commercial/sync/stagingSyncService.ts
+++ b/src/commercial/sync/stagingSyncService.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { extractMetadataFromCode } from '../../frontmatter';
+import { extractMetadataFromCode, resolveReferencePath } from '../../frontmatter';
 import { MermaidChartAuthenticationProvider } from '../../mermaidChartAuthenticationProvider';
 import { setPendingLoginTrigger } from '../../loginTrigger';
 import type { MermaidChartVSCode } from '../../mermaidChartVSCode';
@@ -9,9 +9,9 @@ import analytics from '../../analytics';
 import { CreateDiagramFromStageService } from './createDiagramFromStage';
 import {
   buildSourceFileContext,
-  getStagedSourcePaths,
+  getStagedPaths,
+  isMermaidFile,
   readFileAsAddedContext,
-  resolveReferencePath,
   runGit,
 } from './gitStageHelpers';
 
@@ -145,11 +145,15 @@ export class StagingSyncService {
   ): Promise<void> {
     const repoRoot = workspaceFolder.uri.fsPath;
 
-    const sourceStagedPaths = await getStagedSourcePaths(repoRoot);
-    if (sourceStagedPaths === null) {
+    const stagedPaths = await getStagedPaths(repoRoot);
+    if (stagedPaths === null) {
       console.error({ repoRoot }, 'StagingSync: failed to get staged files');
       return;
     }
+
+    // Staging events that only contain .mmd/.mermaid files aren't source changes
+    // that drive diagram work.
+    const sourceStagedPaths = stagedPaths.filter((p) => !isMermaidFile(p));
     if (sourceStagedPaths.length === 0) {
       return;
     }
@@ -162,6 +166,7 @@ export class StagingSyncService {
       await StagingSyncService.handleRegeneratePath(
         workspaceFolder,
         sourceStagedPaths,
+        stagedPaths.filter(isMermaidFile),
         mcAPI,
       );
     }
@@ -173,6 +178,7 @@ export class StagingSyncService {
   private static async handleRegeneratePath(
     workspaceFolder: vscode.WorkspaceFolder,
     sourceStagedPaths: string[],
+    stagedMmdFiles: string[],
     mcAPI: MermaidChartVSCode,
   ): Promise<void> {
     const repoRoot = workspaceFolder.uri.fsPath;
@@ -182,23 +188,12 @@ export class StagingSyncService {
     //   2. Has unstaged modifications — regenerated but not yet staged, OR was
     //      staged then unstaged (git restore --staged). In both cases the
     //      regenerated content is already on disk; no popup needed.
-    const allStagedResult = await runGit(
-      ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
-      repoRoot,
-    );
-    const allStagedPaths = (allStagedResult?.stdout.trim() ?? '')
-      .split('\n')
-      .filter(Boolean)
-      .map((p) => path.join(repoRoot, p));
-
-    const stagedMmdPaths = new Set(
-      allStagedPaths.filter((p) => p.endsWith('.mmd') || p.endsWith('.mermaid')),
-    );
+    const stagedMmdPaths = new Set(stagedMmdFiles);
 
     const unstagedResult = await runGit(['diff', '--name-only'], repoRoot);
     if (unstagedResult?.stdout) {
       for (const rel of unstagedResult.stdout.split('\n').filter(Boolean)) {
-        if (rel.endsWith('.mmd') || rel.endsWith('.mermaid')) {
+        if (isMermaidFile(rel)) {
           stagedMmdPaths.add(path.join(repoRoot, rel));
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ import { showUpgradePrompt } from "./upgradePricing";
 import { RemoteSyncHandler } from "./remoteSyncHandler";
 import { registerRegenerateCommand } from './commercial/sync/regenerateCommand';
 import { registerRegenerateWithMermaidAICommand } from './commercial/sync/regenerateWithMermaidAICommand';
-import { PreCommitSyncService } from './commercial/sync/preCommitSyncService';
+import { StagingSyncService } from './commercial/sync/stagingSyncService';
 import { initializeAIChatParticipant } from "./commercial/ai/chatParticipant";
 import {
   setPreviewBridge,
@@ -52,6 +52,7 @@ import {
   setValidationBridge,
   setDiagramDiffBridge,
   initializePlugin,
+  setGenerateFromCodeFileRefs,
 } from "@mermaid-chart/vscode-utils";;
 import { PreviewBridgeImpl } from "./commercial/ai/tools/previewTool";
 import { ValidationBridgeImpl } from "./commercial/ai/tools/validationTool";
@@ -65,6 +66,10 @@ import * as packageJson from '../package.json';
 import { clearTmLanguageCache } from "./syntaxHighlighter";
 import { AppReviewFeature } from "./appReviewFeature";
 import { getWorkspaceRoot, installSkillPack, isInstalled } from "./services/aiSkillsInstaller";
+import {
+  recordInteraction,
+  shouldShowPrompt,
+} from "./commercial/sync/interactionCooldown";
 
 
 const pluginID = packageJson.name === "vscode-mermaid-chart" ?  "MERMAIDCHART_VS_CODE_PLUGIN" : "MERMAID_PREVIEW_VS_CODE_PLUGIN";
@@ -958,10 +963,12 @@ context.subscriptions.push(
 );
 
 // Register the generate diagram from code command
+// Optional fileUris: set by on-commit generate popup to seed Copilot references.
+// CodeLens / palette call with no args — existing behavior unchanged.
 context.subscriptions.push(
   vscode.commands.registerCommand(
     "mermaidChart.generateDiagramFromCode",
-    async () => {
+    async (fileUris?: vscode.Uri[] | string[]) => {
       try {
         // Check if Copilot Chat is available
         const copilotExtension = vscode.extensions.getExtension("GitHub.copilot-chat");
@@ -976,6 +983,13 @@ context.subscriptions.push(
             await vscode.commands.executeCommand("extension.open", "GitHub.copilot-chat");
           }
           return;
+        }
+
+        if (fileUris && fileUris.length > 0) {
+          const uris = fileUris.map((u) =>
+            typeof u === "string" ? vscode.Uri.file(u) : u,
+          );
+          setGenerateFromCodeFileRefs(uris);
         }
         
         await vscode.commands.executeCommand("workbench.action.chat.open", {
@@ -1060,15 +1074,14 @@ context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
 // Register the regenerate command from commercial directory
 registerRegenerateCommand(context, mcAPI);
 registerRegenerateWithMermaidAICommand(context, mcAPI);
-PreCommitSyncService.register(context, mcAPI);
+StagingSyncService.register(context, mcAPI);
 
 // ── AI Skills Pack (GitHub Copilot only) ────────────────────────────────────
 
 /** Set to false before release — when true, toast shows on every activate (no globalState). */
 const aiSkillsToastAlwaysShowForTesting = false;
 
-const aiSkillsToastLastShownKey = "mermaidAiSkills.toastLastShownAt";
-const oneMonthMs = 30 * 24 * 60 * 60 * 1000;
+const aiSkillsToastStateKey = "mermaidAiSkills.toast";
 
 async function showAiSkillsToast(): Promise<void> {
   const config = vscode.workspace.getConfiguration("mermaidChart");
@@ -1079,11 +1092,14 @@ async function showAiSkillsToast(): Promise<void> {
   // Stop prompting once skills are actually installed in the workspace
   if (root && isInstalled(root)) { return; }
 
-  if (!aiSkillsToastAlwaysShowForTesting) {
-    // Re-prompt at most once per month until the user adds skills
-    const lastShownAt = context.globalState.get<number>(aiSkillsToastLastShownKey, 0);
-    if (lastShownAt > 0 && Date.now() - lastShownAt < oneMonthMs) { return; }
-  }
+  const cooldownOpts = {
+    globalState: context.globalState,
+    stateKeyPrefix: aiSkillsToastStateKey,
+    alwaysShow: aiSkillsToastAlwaysShowForTesting,
+    maxInteractionsBeforeCooldown: 1,
+  };
+
+  if (!shouldShowPrompt(cooldownOpts)) { return; }
 
   const choice = await vscode.window.showInformationMessage(
     "Mermaid Extension has an AI Skills Pack for GitHub Copilot — teach Copilot to use Mermaid tools and commands to generate and preview diagrams correctly.",
@@ -1091,10 +1107,8 @@ async function showAiSkillsToast(): Promise<void> {
     "Ignore"
   );
 
-  if (!aiSkillsToastAlwaysShowForTesting) {
-    // Ignore / dismiss only delays the next prompt by one month — does not stop forever
-    context.globalState.update(aiSkillsToastLastShownKey, Date.now());
-  }
+  // Count this show toward the monthly cooldown (Ignore / dismiss / accept alike)
+  await recordInteraction(cooldownOpts);
 
   if (choice === "Add Mermaid Skills") {
     vscode.commands.executeCommand("mermaidChart.installAiSkills");

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -235,6 +235,48 @@ function sanitizeQuery(query: string): string {
     .join("\n"); 
 }
 
+/** Path portion of a reference like "File: /src/auth.ts", before workspace resolution. */
+function extractReferencePath(reference: string): string | undefined {
+  // Stop at " (" so a trailing annotation is dropped, but keep spaces that are
+  // part of the path itself.
+  const match = reference.match(/File:\s*(.+?)(?:\s+\(|$)/);
+  return match ? match[1].trim() : undefined;
+}
+
+/** A bare filename carries no directory information, so it can't be resolved. */
+function hasDirectorySegment(filePath: string): boolean {
+  return filePath.includes('/') || filePath.includes('\\');
+}
+
+/**
+ * A leading "/" in a reference means workspace-relative (not POSIX root), so only
+ * Windows drive paths (e.g. C:\...) are treated as truly absolute and used as-is.
+ */
+function toWorkspaceAbsolutePath(filePath: string, workspacePath: string): string {
+  if (/^[a-zA-Z]:[\\/]/.test(filePath)) {
+    return path.normalize(filePath);
+  }
+  if (workspacePath) {
+    return path.normalize(path.join(workspacePath, filePath.replace(/^[/\\]+/, '')));
+  }
+  return path.normalize(filePath);
+}
+
+/**
+ * Resolve the absolute path a frontmatter reference points at.
+ * Returns undefined when the reference has no usable "File: <path>" entry.
+ */
+export function resolveReferencePath(
+  reference: string,
+  workspacePath: string,
+): string | undefined {
+  const filePath = extractReferencePath(reference);
+  if (filePath === undefined || !hasDirectorySegment(filePath)) {
+    return undefined;
+  }
+  return toWorkspaceAbsolutePath(filePath, workspacePath);
+}
+
 export function checkReferencedFiles(metadata: any, workspacePath: string = ''): string[] {
   const changedReferences: string[] = [];
 
@@ -252,28 +294,16 @@ export function checkReferencedFiles(metadata: any, workspacePath: string = ''):
   }
 
   for (const reference of metadata.references) {
-    // Extract file path from reference (assuming format "File: /path/to/file")
-    const match = reference.match(/File: (.*?)(\s|$|\()/);
-    if (!match) continue;
-
-    let filePath = match[1].trim();
+    const rawPath = extractReferencePath(reference);
+    if (rawPath === undefined) continue;
 
     // Early return if reference only contains a filename without a path
-    if (!filePath.includes('/') && !filePath.includes('\\')) {
-      console.log(`Skipping reference without path: ${filePath}`);
+    if (!hasDirectorySegment(rawPath)) {
+      console.log(`Skipping reference without path: ${rawPath}`);
       return [];
     }
 
-    // Windows absolute path (e.g. C:\proj\src\auth.ts) — use as-is.
-    // On POSIX, path.isAbsolute('/src/auth.ts') is true but that path is
-    // workspace-relative by convention, so we check for a drive letter explicitly.
-    if (/^[a-zA-Z]:[\\/]/.test(filePath)) {
-      filePath = path.normalize(filePath);
-    } else if (workspacePath) {
-      // Strip any leading slashes/backslashes (workspace-relative convention).
-      const relative = filePath.replace(/^[/\\]+/, '');
-      filePath = path.normalize(path.join(workspacePath, relative));
-    }
+    const filePath = toWorkspaceAbsolutePath(rawPath, workspacePath);
 
     if (!fs.existsSync(filePath)) {
       changedReferences.push(`${filePath} (deleted)`);

--- a/src/remoteSyncHandler.ts
+++ b/src/remoteSyncHandler.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { MermaidChartVSCode } from './mermaidChartVSCode';
 import { getDiagramFromCache, updateDiagramInCache } from './mermaidChartProvider';
 import { openDiagramDiffWebviews } from './commercial/sync/diagramDiffView';
+import analytics from './analytics';
 
 
 export class RemoteSyncHandler {
@@ -51,6 +52,8 @@ export class RemoteSyncHandler {
                 updateDiagramInCache(diagramId, remoteVersion.code);
                 return 'continue';
             }
+
+            analytics.trackRemoteSync();
 
             // Show non-modal notification at bottom right
             const result = await vscode.window.showInformationMessage(


### PR DESCRIPTION
## Summary
- Soft pop-up when staging coding files that have **no** linked `.mmd` / `.mermaid` — offer Generate Diagram From Code (never blocks commit).
- Split staging into regenerate (linked diagrams) vs create-from-stage (unlinked), sharing one `.git/index` watcher.
- Throttle: after **2** decisions (accept or dismiss), quiet for ~1 month 
- Analytics: On-Commit Diagram Generate Show / Generation Decision (`accepted` | `dismissed`).



Setting: `mermaidChart.createDiagramFromStage.enabled` (default `true`).



**Do not merge until:**
1. vscode-commercial PLUG-90 is merged and **`@mermaid-chart/vscode-utils@1.4.7`**
2. This repo’s `package.json` dependency is updated from `1.4.6` → **`1.4.7`** (or the published version)
3. Lockfile is refreshed (`pnpm install`) and Extension Host is reloaded

Without that bump, Accept on the toast will fail (missing export) and staged files will not seed into Copilot.

https://github.com/Mermaid-Chart/vscode-commercial/pull/24