### PR TITLE
PLUG-81-Update Review UI For Regenerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ When you stage source files that are not yet referenced by any `.mmd` or `.merma
 ### Regenerate Diagram with Diff Preview
 - **Source File Integration**: When you create a .mmd file using any source file with our Mermaid handler, references get added to the front matter.<br>
 - **Smart Change Detection**: When you change your source file code, we provide a regenerate diagram option that reflects the same changes to the Mermaid diagram.<br>
-- **Diff Preview Visualization**: Includes diagram diff preview to help you understand exactly what changed before applying updates.<br>
+- **Review Diff Preview**: Opens the same review UI used for Mermaid Sync app review — summary of added/changed/removed elements, highlighted diagram preview, and optional Diff code / side-by-side compare before you apply updates.<br>
 - **Synchronized Updates**: Ensures your diagrams stay synchronized with your evolving codebase through intelligent change tracking.<br>
 
 ![vscode-plugin-regenerate-preview](https://mermaid.ai/docs/img/plugins/vscode-plugin-regenerate-preview.gif)

--- a/src/commercial/sync/diagramDiffHighlighter.ts
+++ b/src/commercial/sync/diagramDiffHighlighter.ts
@@ -475,14 +475,20 @@ export async function createHighlightInstructions(
     };
   };
 
-  // Process all node changes
+  // Process all node changes — role-aware: Before = removed+modified, After = added+modified
   diff.addedNodes.forEach(nodeId => newDiagramInstructions.push(createNodeInstruction(nodeId, newAST, 'added')));
-  diff.modifiedNodes.forEach(nodeId => newDiagramInstructions.push(createNodeInstruction(nodeId, newAST, 'modified')));
+  diff.modifiedNodes.forEach(nodeId => {
+    newDiagramInstructions.push(createNodeInstruction(nodeId, newAST, 'modified'));
+    oldDiagramInstructions.push(createNodeInstruction(nodeId, oldAST, 'modified'));
+  });
   diff.removedNodes.forEach(nodeId => oldDiagramInstructions.push(createNodeInstruction(nodeId, oldAST, 'removed')));
 
-  // Process all edge changes
+  // Process all edge changes — same role split as nodes
   diff.addedEdges.forEach(edgeId => newDiagramInstructions.push(createEdgeInstruction(edgeId, newAST, 'added')));
-  diff.modifiedEdges.forEach(edgeId => newDiagramInstructions.push(createEdgeInstruction(edgeId, newAST, 'modified')));
+  diff.modifiedEdges.forEach(edgeId => {
+    newDiagramInstructions.push(createEdgeInstruction(edgeId, newAST, 'modified'));
+    oldDiagramInstructions.push(createEdgeInstruction(edgeId, oldAST, 'modified'));
+  });
   diff.removedEdges.forEach(edgeId => oldDiagramInstructions.push(createEdgeInstruction(edgeId, oldAST, 'removed')));
 
   return { newDiagramInstructions, oldDiagramInstructions };

--- a/src/commercial/sync/diagramDiffView.ts
+++ b/src/commercial/sync/diagramDiffView.ts
@@ -230,7 +230,6 @@ export interface ReviewDiagramPreviewOptions {
   oldContent: string;
   fileName: string;
   fileUri?: vscode.Uri;
-  reviewRef?: string;
   onCompareSideBySide?: () => void;
   onViewDiffCode?: () => void;
 }
@@ -471,7 +470,6 @@ export async function openReviewDiagramPreview(
       addedNodeIds: options.addedNodeIds,
       modifiedNodeIds: options.modifiedNodeIds,
       removedNodeIds: options.removedNodeIds,
-      reviewRef: options.reviewRef,
       currentTheme: theme,
       vscodeThemeName,
       fileName: options.fileName,
@@ -671,7 +669,6 @@ function wireReviewDiagramMessages(
 }
 
 export interface OpenAppReviewDiagramOptions {
-  reviewRef?: string;
   onViewDiffCode?: () => void;
   /**
    * When true, Diff code save writes the proposal into `fileUri`
@@ -792,7 +789,7 @@ export async function openTemporaryCodeDiff(
  * Entry point for Mermaid Sync app review ("Review changes"): opens the review
  * diagram webview with chrome, AST diff + review chrome highlights, and optional side-by-side diff.
  *
- * Also used by remote-sync + regenerate (PLUG-81) via the diagram-diff bridge.
+ * Also used by regenerate (PLUG-81) via the diagram-diff bridge.
  */
 export async function openAppReviewDiagramSurface(
   fileUri: vscode.Uri,
@@ -857,7 +854,6 @@ export async function openAppReviewDiagramSurface(
       oldContent,
       fileName,
       fileUri,
-      reviewRef: surfaceOptions.reviewRef,
       onCompareSideBySide: openSideBySide,
       onViewDiffCode: openDiffCode,
     },

--- a/src/commercial/sync/diagramDiffView.ts
+++ b/src/commercial/sync/diagramDiffView.ts
@@ -1,5 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
+import * as os from "node:os";
+import * as crypto from "crypto";
 import { splitFrontMatter } from "../../frontmatter";
 import { setupDiagramDiffPreview } from "../../diagramDiffPreview";
 import { debounce } from "../../utils/debounce";
@@ -18,7 +20,9 @@ import {
 import { getThemeColors } from "../../../webview/src/themes/themeConfig";
 import { saveDiagramAsPng, saveDiagramAsSvg } from "../../services/renderService";
 import analytics from "../../analytics";
+import { prepareMermaidDiffDocuments } from "../../syntaxHighlighter";
 
+const diagramTypeWords: Record<string, string[]> = require("../../diagramTypeWords.json");
 const EXTENSION_ID = `${packageJson.publisher}.${packageJson.name}`;
 
 let cachedExtensionPath: string | undefined;
@@ -92,24 +96,33 @@ function wirePreviewDocumentSync(
   );
 }
 
-function applyDiffHighlights(
-  panelCurrent: vscode.WebviewPanel | undefined,
-  panelUpdated: vscode.WebviewPanel | undefined,
-  newDiagramInstructions: HighlightInstruction[],
-  oldDiagramInstructions: HighlightInstruction[],
-): void {
-  if (newDiagramInstructions.length > 0) {
-    panelUpdated?.webview.postMessage({
-      type: "applyHighlights",
-      highlights: newDiagramInstructions,
-    });
-  }
-  if (oldDiagramInstructions.length > 0) {
-    panelCurrent?.webview.postMessage({
-      type: "applyHighlights",
-      highlights: oldDiagramInstructions,
-    });
-  }
+/** Post highlights after webview boots — early posts are dropped (18MB bundle). */
+function createHighlightSender(
+  panel: vscode.WebviewPanel,
+  getInstructions: () => HighlightInstruction[],
+  disposables: vscode.Disposable[],
+): () => void {
+  let rendered = false;
+
+  const post = (): void => {
+    const highlights = getInstructions();
+    if (!rendered || highlights.length === 0) {
+      return;
+    }
+    void panel.webview.postMessage({ type: "applyHighlights", highlights });
+  };
+
+  // App.svelte already re-applies stored highlights on each render; ack is enough.
+  disposables.push(
+    panel.webview.onDidReceiveMessage((message: { type?: string }) => {
+      if (message?.type === "diagramRendered") {
+        rendered = true;
+        post();
+      }
+    }),
+  );
+
+  return post;
 }
 
 /** Review chrome — green/amber/red CSS + stagger via previewTemplate inline script. */
@@ -240,6 +253,10 @@ export function openDiagramDiffWebviews(
   let panelCurrent: vscode.WebviewPanel | undefined;
   let panelUpdated: vscode.WebviewPanel | undefined;
   const disposables: vscode.Disposable[] = [];
+  let newDiagramInstructions: HighlightInstruction[] = [];
+  let oldDiagramInstructions: HighlightInstruction[] = [];
+  let sendUpdatedHighlights: (() => void) | undefined;
+  let sendCurrentHighlights: (() => void) | undefined;
 
   const disposePanels = (): void => {
     for (const disposable of disposables) {
@@ -282,6 +299,17 @@ export function openDiagramDiffWebviews(
     wirePreviewDocumentSync(panelCurrent, options?.currentRepairDocumentUri, disposables);
     wirePreviewDocumentSync(panelUpdated, options?.incomingRepairDocumentUri, disposables);
 
+    sendCurrentHighlights = createHighlightSender(
+      panelCurrent,
+      () => oldDiagramInstructions,
+      disposables,
+    );
+    sendUpdatedHighlights = createHighlightSender(
+      panelUpdated,
+      () => newDiagramInstructions,
+      disposables,
+    );
+
     void vscode.commands.executeCommand("vscode.setEditorLayout", {
       orientation: 0,
       groups: [
@@ -311,18 +339,12 @@ export function openDiagramDiffWebviews(
           oldDiagramInstructions: [] as HighlightInstruction[],
         };
       })
-      .then(({ newDiagramInstructions, oldDiagramInstructions }) => {
-        if (newDiagramInstructions.length === 0 && oldDiagramInstructions.length === 0) {
-          return;
-        }
-        setTimeout(() => {
-          applyDiffHighlights(
-            panelCurrent,
-            panelUpdated,
-            newDiagramInstructions,
-            oldDiagramInstructions
-          );
-        }, 400);
+      .then((instructions) => {
+        newDiagramInstructions = instructions.newDiagramInstructions;
+        oldDiagramInstructions = instructions.oldDiagramInstructions;
+        // Covers the case where the webview finished rendering before the diff resolved.
+        sendUpdatedHighlights?.();
+        sendCurrentHighlights?.();
       });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -651,11 +673,126 @@ function wireReviewDiagramMessages(
 export interface OpenAppReviewDiagramOptions {
   reviewRef?: string;
   onViewDiffCode?: () => void;
+  /**
+   * When true, Diff code save writes the proposal into `fileUri`
+   * (regenerate — proposal is not in the file yet).
+   */
+  applyProposalOnDiffSave?: boolean;
+}
+
+export interface OpenTemporaryCodeDiffOptions {
+  /** When set, saving the after/right side applies that text into this document. */
+  applyToUri?: vscode.Uri;
+  /** Called after a successful apply-to-file from Diff code save. */
+  onApplied?: (text: string) => void;
+}
+
+/**
+ * Opens a disposable vscode.diff for old vs new content (line-diff / Diff code).
+ * Creates `.mmd` temps, applies Mermaid syntax highlighting, optional apply-on-save.
+ */
+export async function openTemporaryCodeDiff(
+  oldContent: string,
+  newContent: string,
+  title: string,
+  options?: OpenTemporaryCodeDiffOptions,
+): Promise<() => void> {
+  const id = crypto.randomBytes(6).toString("hex");
+  const sessionDir = path.join(os.tmpdir(), "vscode-mermaid-chart-diff", id);
+  const sessionDirUri = vscode.Uri.file(sessionDir);
+  const originalTempUri = vscode.Uri.file(path.join(sessionDir, "before.mmd"));
+  const updatedTempUri = vscode.Uri.file(path.join(sessionDir, "after.mmd"));
+
+  await vscode.workspace.fs.createDirectory(sessionDirUri);
+  await vscode.workspace.fs.writeFile(originalTempUri, Buffer.from(oldContent, "utf8"));
+  await vscode.workspace.fs.writeFile(updatedTempUri, Buffer.from(newContent, "utf8"));
+
+  // prepareMermaidDiffDocuments swallows per-uri errors; never throws to here.
+  await prepareMermaidDiffDocuments([originalTempUri, updatedTempUri], diagramTypeWords);
+
+  await vscode.commands.executeCommand("vscode.diff", originalTempUri, updatedTempUri, title, {
+    preview: false,
+    viewColumn: vscode.ViewColumn.Beside,
+  });
+
+  let cleaned = false;
+  const cleanup = (): void => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    saveDisposable?.dispose();
+    void vscode.workspace.fs.delete(sessionDirUri, { recursive: true }).then(undefined, () => undefined);
+  };
+
+  let saveDisposable: vscode.Disposable | undefined;
+  const applyToUri = options?.applyToUri;
+  const canApply =
+    !!applyToUri &&
+    (applyToUri.scheme === "file" || applyToUri.scheme === "untitled");
+
+  if (applyToUri && !canApply) {
+    console.error(
+      { scheme: applyToUri.scheme, uri: applyToUri.toString() },
+      "Refusing Diff code applyToUri — only file/untitled schemes are allowed",
+    );
+  }
+
+  if (canApply && applyToUri) {
+    const targetUri = applyToUri;
+    saveDisposable = vscode.workspace.onDidSaveTextDocument(async (saved) => {
+      if (saved.uri.toString() !== updatedTempUri.toString()) {
+        return;
+      }
+      try {
+        const text = saved.getText();
+        const targetDoc = await vscode.workspace.openTextDocument(targetUri);
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(
+          targetUri,
+          new vscode.Range(0, 0, targetDoc.lineCount, 0),
+          text,
+        );
+        await vscode.workspace.applyEdit(edit);
+        options?.onApplied?.(text);
+        vscode.window.showInformationMessage("Saved changes from Diff code applied successfully");
+      } catch (error) {
+        console.error({ err: error }, "Failed to apply Diff code save to diagram file");
+        vscode.window.showErrorMessage(
+          `Failed to apply changes: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    });
+  }
+
+  const tabWatcher = vscode.window.tabGroups.onDidChangeTabs(({ closed }) => {
+    for (const tab of closed) {
+      if (!(tab.input instanceof vscode.TabInputTextDiff)) {
+        continue;
+      }
+      const { original, modified } = tab.input;
+      if (
+        original.toString() === originalTempUri.toString() &&
+        modified.toString() === updatedTempUri.toString()
+      ) {
+        tabWatcher.dispose();
+        cleanup();
+        return;
+      }
+    }
+  });
+
+  return () => {
+    tabWatcher.dispose();
+    cleanup();
+  };
 }
 
 /**
  * Entry point for Mermaid Sync app review ("Review changes"): opens the review
  * diagram webview with chrome, AST diff + review chrome highlights, and optional side-by-side diff.
+ *
+ * Also used by remote-sync + regenerate (PLUG-81) via the diagram-diff bridge.
  */
 export async function openAppReviewDiagramSurface(
   fileUri: vscode.Uri,
@@ -672,16 +809,42 @@ export async function openAppReviewDiagramSurface(
 
   if (!surfaceDiff.astAvailable) {
     vscode.window.showWarningMessage(
-      "Diagram diff highlights are only available for flowchart and sequence diagrams.",
+      "Diagram element highlights aren't available for this diagram type. Use Diff code for a line-by-line comparison.",
     );
   }
 
   const contentRefs = { oldContent, newContent };
   let splitDispose: (() => void) | undefined;
+  let codeDiffDispose: (() => void) | undefined;
+  let panelAlreadyDisposed = false;
+  let previewRef: Awaited<ReturnType<typeof openReviewDiagramPreview>> | undefined;
+
   const openSideBySide = (): void => {
     splitDispose?.();
     splitDispose = openDiagramDiffWebviews(contentRefs.oldContent, contentRefs.newContent);
   };
+
+  const openDiffCode =
+    surfaceOptions.onViewDiffCode ??
+    (() => {
+      void openTemporaryCodeDiff(
+        contentRefs.oldContent,
+        contentRefs.newContent,
+        `Diagram Diff: ${fileName}`,
+        surfaceOptions.applyProposalOnDiffSave
+          ? {
+              applyToUri: fileUri,
+              onApplied: (text) => {
+                contentRefs.newContent = text;
+                void previewRef?.refreshFromContent(text);
+              },
+            }
+          : undefined,
+      ).then((dispose) => {
+        codeDiffDispose?.();
+        codeDiffDispose = dispose;
+      });
+    });
 
   const preview = await openReviewDiagramPreview(
     {
@@ -696,11 +859,17 @@ export async function openAppReviewDiagramSurface(
       fileUri,
       reviewRef: surfaceOptions.reviewRef,
       onCompareSideBySide: openSideBySide,
-      onViewDiffCode: surfaceOptions.onViewDiffCode,
+      onViewDiffCode: openDiffCode,
     },
     newContent,
     vscode.ViewColumn.Active,
   );
+  previewRef = preview;
+
+  preview.panel?.reveal(vscode.ViewColumn.Active, false);
+  preview.panel?.onDidDispose(() => {
+    panelAlreadyDisposed = true;
+  });
 
   if (!preview.panel) {
     vscode.window.showErrorMessage(
@@ -709,17 +878,26 @@ export async function openAppReviewDiagramSurface(
   }
 
   const closePanels = (): void => {
-    try {
-      preview.dispose();
-    } catch {
-      /* best-effort */
+    if (!panelAlreadyDisposed) {
+      try {
+        preview.dispose();
+      } catch {
+        /* best-effort */
+      }
+      panelAlreadyDisposed = true;
     }
     try {
       splitDispose?.();
     } catch {
       /* best-effort */
     }
+    try {
+      codeDiffDispose?.();
+    } catch {
+      /* best-effort */
+    }
     splitDispose = undefined;
+    codeDiffDispose = undefined;
   };
 
   const refreshFromContent = async (updatedContent: string): Promise<void> => {

--- a/src/commercial/sync/reviewChrome.ts
+++ b/src/commercial/sync/reviewChrome.ts
@@ -10,10 +10,6 @@ const SAVE_ICON_SVG = /* svg */ `<svg class="mc-pill-icon" width="14" height="14
   <path d="M8 1.5v5h4.5" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
 </svg>`;
 
-const BRANCH_ICON_SVG = /* svg */ `<svg class="mc-pill-icon" width="14" height="14" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-  <path d="M4.5 3.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm7 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM6 5v2.2c0 .8.5 1.5 1.2 1.8L10 10v1.5H6V14h4.5a1 1 0 0 0 1-1V9.8L8.2 8.2A1.5 1.5 0 0 1 7.5 6.5V5H6z"/>
-</svg>`;
-
 /** Shared chrome — dark rounded pills matching product toolbar reference. */
 export function reviewChromeStyles(): string {
     return /* css */ `
@@ -25,7 +21,6 @@ export function reviewChromeStyles(): string {
     --mc-dot-added: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
     --mc-dot-modified: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
     --mc-dot-removed: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
-    --mc-dot-branch: var(--vscode-charts-teal, #2dd4bf);
     --mc-dot-now: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
     --mc-save-accent: #e879a8;
     font-family: var(--vscode-font-family);
@@ -87,7 +82,6 @@ export function reviewChromeStyles(): string {
   .mc-status-dot.added { background: var(--mc-dot-added); }
   .mc-status-dot.modified { background: var(--mc-dot-modified); }
   .mc-status-dot.removed { background: var(--mc-dot-removed); }
-  .mc-status-dot.branch { background: var(--mc-dot-branch); }
   .mc-status-dot.theme {
     background: conic-gradient(#ff6b6b, #feca57, #48dbfb, #ff9ff3, #ff6b6b);
   }
@@ -104,7 +98,6 @@ export function reviewChromeStyles(): string {
     flex-shrink: 0;
     opacity: 0.95;
   }
-  .mc-pill-branch .mc-pill-icon { color: var(--mc-dot-branch); }
   .mc-pill-action .mc-pill-icon { color: var(--mc-save-accent); }
 
   /* Theme pill trigger — original review chrome button */
@@ -480,18 +473,6 @@ export function renderHeaderActionButtons(): string {
         `${SAVE_ICON_SVG}<span class="mc-pill-label">Save diagram</span></button>` +
         `<button type="button" class="mc-pill mc-review-chrome" data-action="view-diff-code" title="Open source diff in editor">` +
         `<span class="mc-pill-label">Diff code</span></button>`
-    );
-}
-
-export function renderMetaChips(opts: { reviewRef?: string }): string {
-    if (!opts.reviewRef?.trim()) {
-        return "";
-    }
-    const ref = escapeHtml(opts.reviewRef.trim());
-    return (
-        `<span class="mc-pill mc-pill-branch mc-review-chrome" title="Review reference">` +
-        `${BRANCH_ICON_SVG}` +
-        `<span class="mc-pill-label">${ref}</span></span>`
     );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ import {
 import { PreviewBridgeImpl } from "./commercial/ai/tools/previewTool";
 import { ValidationBridgeImpl } from "./commercial/ai/tools/validationTool";
 import {
+  openAppReviewDiagramSurface,
   openDiagramDiffWebviews,
   setReviewDiagramExtensionPath,
 } from "./commercial/sync/diagramDiffView";
@@ -121,7 +122,21 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize the bridge for commercial tools
   setPreviewBridge(new PreviewBridgeImpl());
   setValidationBridge(new ValidationBridgeImpl());
-  setDiagramDiffBridge({ openDiagramDiffWebviews });
+  setDiagramDiffBridge({
+    openDiagramDiffWebviews,
+    openDiagramReviewSurface: async (options) => {
+      const result = await openAppReviewDiagramSurface(
+        options.fileUri,
+        options.oldContent,
+        options.newContent,
+        {
+          reviewRef: options.reviewRef,
+          applyProposalOnDiffSave: options.applyProposalOnDiffSave,
+        },
+      );
+      return { closePanels: result.closePanels, panel: result.panel };
+    },
+  });
   
   // Initialize AI chat participant after tools are registered
   initializeAIChatParticipant(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,10 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
         options.fileUri,
         options.oldContent,
         options.newContent,
-        {
-          reviewRef: options.reviewRef,
-          applyProposalOnDiffSave: options.applyProposalOnDiffSave,
-        },
+        { applyProposalOnDiffSave: options.applyProposalOnDiffSave },
       );
       return { closePanels: result.closePanels, panel: result.panel };
     },

--- a/src/syntaxHighlighter.ts
+++ b/src/syntaxHighlighter.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
+import { getFirstWordFromDiagram } from './frontmatter';
 
 // Function to map the first word to a diagram type
 export function getDiagramTypeFromWord(firstWord: string, diagramMappings: Record<string, string[]>): string | null {
@@ -48,6 +50,45 @@ export function applySyntaxHighlighting(document: vscode.TextDocument, tmLanguag
         console.error('Failed to apply syntax highlighting:', error);
       }
     );
+  }
+}
+
+/**
+ * Open temp/diff documents and set Mermaid language so vscode.diff shows syntax highlighting.
+ * Prefer type-specific grammar (mermaid.flowchart, …) when mappings are available.
+ */
+export async function prepareMermaidDiffDocuments(
+  uris: vscode.Uri[],
+  diagramMappings?: Record<string, string[]>,
+): Promise<void> {
+  for (const uri of uris) {
+    try {
+      const doc = await vscode.workspace.openTextDocument(uri);
+      let languageId = 'mermaid';
+
+      if (diagramMappings) {
+        const firstWord = getFirstWordFromDiagram(doc.getText());
+        const diagramType = firstWord
+          ? getDiagramTypeFromWord(firstWord, diagramMappings)
+          : null;
+        if (diagramType) {
+          const grammarPath = path.join(
+            __dirname,
+            '..',
+            'syntaxes',
+            `mermaid-${diagramType}.tmLanguage.json`,
+          );
+          const tmLanguage = loadTmLanguage(grammarPath);
+          if (tmLanguage?.name) {
+            languageId = `mermaid.${tmLanguage.name}`;
+          }
+        }
+      }
+
+      await vscode.languages.setTextDocumentLanguage(doc, languageId);
+    } catch (error) {
+      console.error({ err: error, uri: uri.toString() }, 'Failed to prepare Mermaid diff document language');
+    }
   }
 }
 

--- a/src/templates/previewTemplate.ts
+++ b/src/templates/previewTemplate.ts
@@ -7,7 +7,6 @@ import {
 import {
     renderChangesList,
     renderHeaderActionButtons,
-    renderMetaChips,
     renderNowBeforeToggle,
     renderSummaryChips,
     renderThemeSelect,
@@ -20,7 +19,6 @@ export interface ReviewDiagramPreviewContext {
     changes: DiagramChangeItem[];
     addedNodeIds: string[];
     modifiedNodeIds: string[];
-  reviewRef?: string;
   themeLabel?: string;
   /** Mermaid theme key passed to the webview renderer. */
   currentTheme?: string;
@@ -613,10 +611,9 @@ export function getWebviewHTML(
 
 function buildReviewDiagramHeader(ctx: ReviewDiagramPreviewContext): string {
     const summary = renderSummaryChips(ctx.counts);
-    const meta = renderMetaChips({ reviewRef: ctx.reviewRef });
     const theme = renderThemeSelect(ctx.currentTheme ?? "redux-dark", ctx.vscodeThemeName);
     const actions = renderHeaderActionButtons();
-    return `<header class="mc-review-header-bar mc-review-chrome"><div id="mc-review-summary-chips">${summary}</div><div class="mc-header-actions mc-review-chrome">${meta}${theme}${actions}</div></header>`;
+    return `<header class="mc-review-header-bar mc-review-chrome"><div id="mc-review-summary-chips">${summary}</div><div class="mc-header-actions mc-review-chrome">${theme}${actions}</div></header>`;
 }
 
 function buildReviewDiagramStage(ctx: ReviewDiagramPreviewContext): string {

--- a/webview/src/App.svelte
+++ b/webview/src/App.svelte
@@ -829,12 +829,13 @@
     cursor: grabbing;
   }
   
+  /* No gap: the sidebars are absolutely positioned, and any leftover height here
+     makes Panzoom's `contain: "outside"` raise minScale above 1 (zoom starts at 101–102%). */
   #app-container {
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100vh;
-    gap: 10px;
     overflow: hidden;
   }
   :global(#app[data-review-diagram="true"]) #app-container {


### PR DESCRIPTION
## Summary
- Wire regenerate through the GitHub App review surface (shared review UI via the commercial bridge).
- Fix side-by-side diagram highlights on remote sync (and other dual-panel diffs) by sending highlights after `diagramRendered` instead of a fixed 400ms delay.

## Note before merge
Merge the **vscode-commercial** PR first and publish a new `@mermaid-chart/vscode-utils` version, then bump that dependency in this repo and remove the local `file:../vscode-commercial` link before merging this PR.